### PR TITLE
feat!: change to transform3 and local2 structs

### DIFF
--- a/plugins/eigen/include/plugins/eigen_defs.hpp
+++ b/plugins/eigen/include/plugins/eigen_defs.hpp
@@ -9,37 +9,97 @@
 
 namespace detray
 {
+    using scalar = float;
+
+    // eigen getter methdos
+    namespace getter
+    {
+        /** This method retrieves phi from a vector, vector base with rows > 2
+         * 
+         * @param v the input vector 
+         **/
+        template <typename derived_type>
+        auto phi(const Eigen::MatrixBase<derived_type> &v) noexcept
+        {
+            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+            static_assert(rows >= 2, "vector::phi() required rows >= 2.");
+            return std::atan2(v[0], v[1]);
+        }
+
+        /** This method retrieves theta from a vector, vector base with rows >= 3
+         * 
+         * @param v the input vector 
+         **/
+        template <typename derived_type>
+        auto theta(const Eigen::MatrixBase<derived_type> &v) noexcept
+        {
+            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+            static_assert(rows >= 2, "vector::theta() required rows >= 3.");
+            return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
+        }
+
+        /** This method retrieves the pseudo-rapidity from a vector or vector base with rows >= 3
+         * 
+         * @param v the input vector 
+         **/
+        template <typename derived_type>
+        auto eta(const Eigen::MatrixBase<derived_type> &v) noexcept
+        {
+            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+            static_assert(rows >= 2, "vector::eta() required rows >= 3.");
+            return std::atanh(v[2] / v.norm());
+        }
+
+        /** This method retrieves the perpenticular magnitude of a vector with rows >= 2
+         * 
+         * @param v the input vector 
+         **/
+        template <typename derived_type>
+        auto perp(const Eigen::MatrixBase<derived_type> &v) noexcept
+        {
+            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+            static_assert(rows >= 2, "vector::perp() required rows >= 2.");
+            return std::sqrt(v[0] * v[0] + v[1] * v[1]);
+        }
+
+        /** This method retrieves the norm of a vector, no dimension restriction
+         * 
+         * @param v the input vector 
+         **/
+        template <typename derived_type>
+        auto norm(const Eigen::MatrixBase<derived_type> &v)
+        {
+            return v.norm();
+        }
+
+        /** This method retrieves a column from a matrix
+         * 
+         * @param m the input matrix 
+         **/
+        template <typename kCOLS, typename kROWS, typename derived_type>
+        auto block(const Eigen::MatrixBase<derived_type> &m, unsigned int col, unsigned int row)
+        {
+            return m.template block<kCOLS, kROWS>(col, row);
+        }
+
+    } // namespace getter
+
     // eigen definitions
     namespace eigen
     {
-        // Primitives definition
-        using scalar = float;
-        using vector2 = Eigen::Matrix<scalar, 2, 1>;
-        using point2 = vector2;
-        using point2pol = Eigen::Matrix<scalar, 2, 1>;
-        using point2cyl = Eigen::Matrix<scalar, 2, 1>;
-        using vector3 = Eigen::Matrix<scalar, 3, 1>;
-        using point3 = vector3;
-
         /** Transform wrapper class to ensure standard API within differnt plugins
          * 
          **/
         struct transform3
         {
-
+            using vector3 = Eigen::Matrix<scalar, 3, 1>;
+            using point3 = vector3;
             using context = std::any;
 
             Eigen::Transform<scalar, 3, Eigen::Affine> _data =
                 Eigen::Transform<scalar, 3, Eigen::Affine>::Identity();
 
             using matrix44 = Eigen::Transform<scalar, 3, Eigen::Affine>::MatrixType;
-
-            /** The contextual transform interface, ignored for the moment
-             **/
-            auto contextual(const context & /*ignored*/) const
-            {
-                return _data;
-            }
 
             /** Contructor with arguments: t, z, x, ctx
              * 
@@ -72,236 +132,199 @@ namespace detray
             /** Constructor with arguments: matrix 
              * 
              * @param mat is the full 4x4 matrix 
+             * 
+             * @note this is a contextual method
              **/
             transform3(const matrix44 &m, const context & /*ctx*/)
             {
                 _data.matrix() = m;
             }
+
+            /** This method retrieves the rotation of a transform
+             * 
+             * @param ctx the context object
+             * 
+             * @note this is a contextual method
+             **/
+            auto rotation(const context & /*ctx*/)
+            {
+                return _data.matrix().block<3, 3>(0, 0).eval();
+            }
+
+            /** This method retrieves the translation of a transform
+             * 
+             * @param ctx the context object
+             * 
+             * @note this is a contextual method
+             **/
+            auto translation(const context & /*ctx*/)
+            {
+                return _data.matrix().block<3, 1>(0, 3).eval();
+            }
+
+            /** This method retrieves the 4x4 matrix of a transform
+             * 
+             * @param ctx the context object
+             * 
+             * @note this is a contextual method
+             **/
+            auto matrix(const context & /*ctx*/)
+            {
+                return _data.matrix();
+            }
+
+            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame
+             * 
+             * @note this is a contextual method 
+             **/
+            template <typename derived_type>
+            const auto point_to_global(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::point_to_global(v) requires a (3,1) matrix");
+                return (_data * v).eval();
+            }
+
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
+             * 
+             * @note this is a contextual method 
+             **/
+            template <typename derived_type>
+            const auto point_to_local(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::point_to_local(v) requires a (3,1) matrix");
+                return (_data.inverse() * v).eval();
+            }
+
+            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame
+             * 
+             * @note this is a contextual method 
+             **/
+            template <typename derived_type>
+            const auto vector_to_global(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::vector_to_global(v) requires a (3,1) matrix");
+                return (_data.linear() * v).eval();
+            }
+
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
+             * 
+             * @note this is a contextual method 
+             **/
+            template <typename derived_type>
+            const auto vector_to_local(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::vector_to_local(v) requires a (3,1) matrix");
+                return (_data.inverse().linear() * v).eval();
+            }
+        };
+
+        /** Non-contextual local frame projection into a cartesian coordinate frame
+         */
+        struct cartesian2
+        {
+            using point2 = Eigen::Matrix<scalar, 2, 1>;
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             */
+            template <typename derived_type>
+            const auto operator()(const Eigen::MatrixBase<derived_type> &v)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::point3_to_point2(v) requires a (3,1) matrix");
+                return v.template segment<2>(0);
+            }
+        };
+
+        /** Non-contextual local frame projection into a polar coordinate frame
+         **/
+        struct polar2
+        {
+            using point2 = Eigen::Matrix<scalar, 2, 1>;
+
+            /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point */
+            template <typename derived_type>
+            const auto operator()(const Eigen::MatrixBase<derived_type> &v)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows >= 2 and cols == 1, "transform::point_to_point2pol(v) requires a (>2,1) matrix");
+                return point2{getter::perp(v), getter::phi(v)};
+            }
+        };
+
+        /** Non-contextual local frame projection into a polar coordinate frame
+         **/
+        struct cylindrical2
+        {
+            using point2 = Eigen::Matrix<scalar, 2, 1>;
+
+            /** This method transform from a point from 2 3D cartesian frame to a 2D cylindrical point */
+            template <typename derived_type>
+            const auto operator()(const Eigen::MatrixBase<derived_type> &v)
+            {
+                constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
+                constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
+                static_assert(rows == 3 and cols == 1, "transform::point3_to_point2cyl(v) requires a a (3,1) matrix");
+                return point2{getter::perp(v) * getter::phi(v), v[2]};
+            }
         };
 
     } // namespace eigen
-
-    // Getter methdos
-    namespace getter
-    {
-        /** This method retrieves phi from a vector, vector base with rows > 2
-         * 
-         * @param v the input vector 
-         **/
-        template <typename derived_type>
-        eigen::scalar phi(const Eigen::MatrixBase<derived_type> &v) noexcept
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            static_assert(rows >= 2, "vector::phi() required rows >= 2.");
-            return std::atan2(v[0], v[1]);
-        }
-
-        /** This method retrieves theta from a vector, vector base with rows >= 3
-         * 
-         * @param v the input vector 
-         **/
-        template <typename derived_type>
-        eigen::scalar theta(const Eigen::MatrixBase<derived_type> &v) noexcept
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            static_assert(rows >= 2, "vector::theta() required rows >= 3.");
-            return std::atan2(std::sqrt(v[0] * v[0] + v[1] * v[1]), v[2]);
-        }
-
-        /** This method retrieves the pseudo-rapidity from a vector or vector base with rows >= 3
-         * 
-         * @param v the input vector 
-         **/
-        template <typename derived_type>
-        eigen::scalar eta(const Eigen::MatrixBase<derived_type> &v) noexcept
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            static_assert(rows >= 2, "vector::eta() required rows >= 3.");
-            return std::atanh(v[2] / v.norm());
-        }
-
-        /** This method retrieves the perpenticular magnitude of a vector with rows >= 2
-         * 
-         * @param v the input vector 
-         **/
-        template <typename derived_type>
-        eigen::scalar perp(const Eigen::MatrixBase<derived_type> &v) noexcept
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            static_assert(rows >= 2, "vector::perp() required rows >= 2.");
-            return std::sqrt(v[0] * v[0] + v[1] * v[1]);
-        }
-
-        /** This method retrieves the norm of a vector, no dimension restriction
-         * 
-         * @param v the input vector 
-         **/
-        template <typename derived_type>
-        eigen::scalar norm(const Eigen::MatrixBase<derived_type> &v)
-        {
-            return v.norm();
-        }
-
-        /** This method retrieves the rotation of a transform
-         * 
-         * @param trf the input transform 
-         * @param ctx the context object
-         * 
-         * @note this is a contextual method
-         **/
-        auto rotation(const eigen::transform3 &trf, const eigen::transform3::context &ctx)
-        {
-            return trf.contextual(ctx).matrix().block<3, 3>(0, 0).eval();
-        }
-
-      /** This method retrieves the translation of a transform
-         * 
-         * @param trf the input transform 
-         * @param ctx the context object
-         * 
-         * @note this is a contextual method
-         **/
-        auto translation(const eigen::transform3 &trf, const eigen::transform3::context &ctx)
-        {
-            return trf.contextual(ctx).matrix().block<3, 1>(0, 3).eval();
-        }
-
-       /** This method retrieves the 4x4 matrix of a transform
-         * 
-         * @param trf the input transform 
-         * @param ctx the context object
-         * 
-         * @note this is a contextual method
-         **/
-        auto matrix(const eigen::transform3 &trf, const eigen::transform3::context &ctx)
-        {
-            return trf.contextual(ctx).matrix();
-        }
-
-
-        /** This method retrieves a column from a matrix
-         * 
-         * @param m the input matrix 
-         **/
-        template <typename kCOLS, typename kROWS, typename derived_type>
-        auto block(const Eigen::MatrixBase<derived_type> &m, unsigned int col, unsigned int row)
-        {
-            return m.template block<kCOLS,kROWS>(col, row);
-        }
-
-
-    } // namespace getter
 
     // Non-contextual vector transfroms
     namespace vector
     {
 
+        /** Get a normalized version of the input vector
+         * 
+         * @tparam derived_type is the matrix template
+         * 
+         * @param v the input vector
+         **/
         template <typename derived_type>
         auto normalize(const Eigen::MatrixBase<derived_type> &v)
         {
             return v.normalized();
         }
 
+        /** Dot product between two input vectors
+         * 
+         * @tparam derived_type is the matrix template
+         * 
+         * @param a the first input vector
+         * @param b the second input vector
+         * 
+         * @return the scalar dot product value 
+         **/
         template <typename derived_type>
         auto dot(const Eigen::MatrixBase<derived_type> &a, const Eigen::MatrixBase<derived_type> &b)
         {
             return a.dot(b);
         }
 
+        /** Cross product between two input vectors
+         * 
+         * @tparam derived_type is the matrix template
+         * 
+         * @param a the first input vector
+         * @param b the second input vector
+         * 
+         * @return a vector (expression) representing the cross product
+         **/
         template <typename derived_type>
         auto cross(const Eigen::MatrixBase<derived_type> &a, const Eigen::MatrixBase<derived_type> &b)
         {
             return a.cross(b);
         }
     } // namespace vector
-
-    // Contextual and non-contextual transform operations
-    namespace transform
-    {
-
-        /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame
-         * 
-         * @note this is a contextual method 
-         * */
-        template <typename derived_type>
-        const auto lpoint3_to_gpoint3(const eigen::transform3 &trf, const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context &ctx)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows == 3 and cols == 1, "transform::lpoint3_to_gpoint3(v) requires a (3,1) matrix");
-            return trf.contextual(ctx) * v;
-        }
-
-        /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame
-        * 
-        * @note this is a contextual method 
-        * */
-        template <typename derived_type>
-        const auto lvector3_to_gvector3(const eigen::transform3 &trf, const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context &ctx)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows == 3 and cols == 1, "transform::lvector3_to_gvector3(v) requires a (3,1) matrix");
-            return (trf.contextual(ctx).linear() * v).eval();
-        }
-
-        /** This method transform from a point from the global 3D cartesian frame to the local 3D cartesian frame
-         * 
-         * @note this is a contextual method 
-         * */
-        template <typename derived_type>
-        const auto gpoint3_to_lpoint3(const eigen::transform3 &trf, const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context &ctx)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows == 3 and cols == 1, "transform::gpoint3_to_lpoint3(v) requires a (3,1) matrix");
-            return (trf.contextual(ctx).inverse() * v).eval();
-        }
-
-        /** This method transform from a vector from the global 3D cartesian frame to the global 3D cartesian frame
-        * 
-        * @note this is a contextual method 
-        * */
-        template <typename derived_type>
-        const auto gvector3_to_lvector3(const eigen::transform3 &trf, const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context &ctx)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows == 3 and cols == 1, "transform::gvector3_to_lvector3(v) requires a (3,1) matrix");
-            return (trf.contextual(ctx).inverse().linear() * v).eval();
-        }
-
-        /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
-        * */
-        template <typename derived_type>
-        const auto point3_to_point2(const Eigen::MatrixBase<derived_type> &v)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows == 3 and cols == 1, "transform::point3_to_point2(v) requires a (3,1) matrix");
-            return v.template segment<2>(0);
-        }
-
-        /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point */
-        template <typename derived_type>
-        eigen::point2pol point_to_point2pol(const Eigen::MatrixBase<derived_type> &v)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows >= 2 and cols == 1, "transform::point_to_point2pol(v) requires a (>2,1) matrix");
-            return {getter::perp(v), getter::phi(v)};
-        }
-
-        /** This method transform from a point from 2 3D cartesian frame to a 2D cylindrical point */
-        template <typename derived_type>
-        const eigen::point2cyl point3_to_point2cyl(const Eigen::MatrixBase<derived_type> &v)
-        {
-            constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
-            constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
-            static_assert(rows == 3 and cols == 1, "transform::point3_to_point2cyl(v) requires a a (3,1) matrix");
-            return {getter::perp(v) * getter::phi(v), v[2]};
-        }
-
-    } // namespace transform
 
 } // namespace detray

--- a/tests/common/core_test.inl
+++ b/tests/common/core_test.inl
@@ -8,17 +8,12 @@
 
 using namespace detray;
 
-using scalar = plugin::scalar;
+using point2 = plugin::cartesian2::point2;
 
-// Two-dimensional definitions
-using vector2 = plugin::vector2;
-using point2 = plugin::vector2;
-using point2pol = plugin::point2pol;
-using point2cyl = plugin::point2cyl;
 // Three-dimensional definitions
-using vector3 = plugin::vector3;
-using point3 = plugin::point3;
 using transform3 = plugin::transform3;
+using vector3 = plugin::transform3::vector3;
+using point3 = plugin::transform3::point3;
 using context = plugin::transform3::context;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
@@ -41,7 +36,7 @@ TEST(plugin, surface)
 // This tests the construction of a intresection
 TEST(plugin, intersection)
 {
-    using intersection = intersection<scalar, vector3, vector2>;
+    using intersection = intersection<scalar, point3, point2>;
 
     intersection i0 = {2., point3(0.3, 0.5, 0.7), std::nullopt};
 
@@ -49,13 +44,12 @@ TEST(plugin, intersection)
 
     intersection invalid;
 
-    std::vector<intersection> intersections = { invalid, i0, i1 };
+    std::vector<intersection> intersections = {invalid, i0, i1};
     std::sort(intersections.begin(), intersections.end());
 
     ASSERT_NEAR(intersections[0].path, 1.7, epsilon);
     ASSERT_NEAR(intersections[1].path, 2, epsilon);
     ASSERT_TRUE(std::isinf(intersections[2].path));
-
 }
 
 // Google Test can be run manually from the main() function


### PR DESCRIPTION
The global transformation is defined by 

```c++
struct transform3 { 

using point3 = ...
using vector3 = ...

};
```

and the types can be deduced from the transform, in order to keep template parameters few.

It also introduces `cartesian2`, `polar2` and `cylindrical2` structs with callable `operator` to retrieve the local coordinate frame type.