### PR TITLE
feat!: first planar intersector

### DIFF
--- a/core/include/tools/planar_intersector.hpp
+++ b/core/include/tools/planar_intersector.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cmath>
+#include <climits>
+
+#include "core/intersection.hpp"
+#include "core/surface.hpp"
+#include "masks/unmasked.hpp"
+
+namespace detray
+{
+
+    /** This is an intersector struct for planar surface
+     */
+    struct planar_intersector
+    {
+        /** A representation that is not bound to a local frame
+         */
+        struct unbound
+        {
+            using point2 = int;
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             */
+            template <typename point3_type>
+            const std::optional<point2> operator()(const point3_type & /*ignored*/) const
+            {
+                return std::nullopt;
+            }
+        };
+
+        /** Intersection method for planar surfaces
+         * 
+         * @tparam surface_type The surface type to be intersected
+         * @tparam local_type The local frame type to be intersected
+         * @tparam mask_type The mask type applied to the local frame
+         * 
+         * Contextual part:
+         * @param s the surface to be intersected
+         * @param ro the origin of the ray
+         * @param rd the direction of the ray
+         * @param ctx the context of the call
+         * 
+         * Non-contextual part:
+         * @param local the local local frame 
+         * @param mask the local mask 
+         * 
+         * @return the intersection with optional parameters
+         **/
+        template <typename surface_type, typename local_type = unbound, typename mask_type = unmasked<>>
+        intersection<scalar, typename surface_type::transform3::point3, typename local_type::point2>
+        intersect(const surface_type &s,
+                  const typename surface_type::transform3::point3 &ro,
+                  const typename surface_type::transform3::vector3 &rd,
+                  const typename surface_type::transform3::context &ctx,
+                  const local_type &local = local_type(),
+                  const mask_type &mask = mask_type()) const
+        {
+
+            using point3 = typename surface_type::transform3::point3;
+            using point2 = typename local_type::point2;
+            using intersection = intersection<scalar, point3, point2>;
+
+            // Retrieve the surface normal & translation (context resolved)
+            auto sm = s.transform().matrix(ctx);
+            auto sn = getter::block<3, 1>(sm, 0, 2);
+            auto st = getter::block<3, 1>(sm, 0, 3);
+
+            // Intersection code
+            scalar denom = vector::dot(rd, sn);
+            if (denom != 0.0)
+            {
+                intersection is;
+                is._path = vector::dot(sn, (st - ro)) / (denom);
+                is._point3 = ro + is._path * rd;
+                is._point2 = local(is._point3);
+                is._status = mask(is._point2);
+
+                return is;
+            }
+            return intersection{};
+        }
+    };
+
+} // namespace detray

--- a/tests/common/planar_intersection_test.inl
+++ b/tests/common/planar_intersection_test.inl
@@ -1,0 +1,53 @@
+
+#include "core/surface.hpp"
+#include "core/intersection.hpp"
+#include "masks/rectangle2.hpp"
+#include "tools/planar_intersector.hpp"
+
+#include <cmath>
+#include <climits>
+
+/// @note plugin has to be defined with a preprocessor command
+using namespace detray;
+
+// Two-dimensional definitions
+using point2cart = plugin::cartesian2::point2;
+plugin::cartesian2 cartesian2;
+
+// Three-dimensional definitions
+using transform3 = plugin::transform3;
+using vector3 = plugin::transform3::vector3;
+using point3 = plugin::transform3::point3;
+using context = plugin::transform3::context;
+
+constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
+constexpr scalar isclose = 1e-5;
+
+
+// This defines the local frame test suite
+TEST(plugin, translated_plane)
+{
+    context ctx;
+    using plane_surface = surface<transform3,int>;
+
+    // Create a shifted plane
+    transform3 shifted(vector3{3., 2., 10.}, ctx);
+    plane_surface shifted_plane(std::move(shifted), 1);
+
+    planar_intersector pi;
+
+    auto hit0 = pi.intersect(shifted_plane, point3{2.,1.,0.}, vector3{0.,0.,1.}, ctx);
+    ASSERT_NEAR(hit0._point3.value()[0], 2., epsilon);
+    ASSERT_NEAR(hit0._point3.value()[1], 1., epsilon);
+    ASSERT_NEAR(hit0._point3.value()[2], 10., epsilon);
+}
+
+// Google Test can be run manually from the main() function
+// or, it can be linked to the gtest_main library for an already
+// set-up main() function primed to accept Google Test test cases.
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/eigen/eigen_planar_intersection.cpp
+++ b/tests/eigen/eigen_planar_intersection.cpp
@@ -1,0 +1,8 @@
+
+#include <gtest/gtest.h>
+
+#include "plugins/eigen_defs.hpp"
+
+#define plugin eigen
+
+#include "../common/planar_intersection_test.inl"


### PR DESCRIPTION
This PR adds a first planar intersector to the project.

Additionally, it introduces a `intersection_status` enum for flagging the intersection type.