### PR TITLE
feat: split off context

### DIFF
--- a/core/include/core/intersection.hpp
+++ b/core/include/core/intersection.hpp
@@ -19,8 +19,8 @@ namespace detray
     enum intersectiondirection : int
     {
         e_undefined = -1, //!< the undefined direction at intersection
-        e_opposite = 0, //!< opposite the surface normal at the intersection
-        e_along = 1      //!< along the surface normal at the intersection
+        e_opposite = 0,   //!< opposite the surface normal at the intersection
+        e_along = 1       //!< along the surface normal at the intersection
     };
 
     /** Intersection status: outside, missed, insidem, hit ( w/o maks status) */
@@ -45,9 +45,9 @@ namespace detray
 
         scalar_type path = std::numeric_limits<scalar_type>::infinity();
         point3_type point3 = point3_type{std::numeric_limits<scalar_type>::infinity(),
-                                          std::numeric_limits<scalar_type>::infinity(),
-                                          std::numeric_limits<scalar_type>::infinity()};
-        
+                                         std::numeric_limits<scalar_type>::infinity(),
+                                         std::numeric_limits<scalar_type>::infinity()};
+
         std::optional<point2_type> point2 = std::nullopt;
         intersection_status status = e_missed;
         intersectiondirection direction = e_undefined;

--- a/core/include/core/surface.hpp
+++ b/core/include/core/surface.hpp
@@ -12,17 +12,17 @@ namespace detray
 {
     /** Templated surface class
      * 
-     * @tparam transform_type the type of the global 3D to local 3D frame
+     * @tparam transform_link the type of the transform/transform link forglobal 3D to local 3D frame
      * @tparam mask_link the type of the mask/mask link representation
      * @tparam volume_link the typ eof the volume/volume link representation
      * @tparam source_link the type of the source/source link representation 
      */
-    template <typename transform_type, typename mask_link = int, typename volume_link = int, typename source_link = bool>
+    template <typename transform_link, typename mask_link = int, typename volume_link = int, typename source_link = bool>
     class surface
     {
     public:
         /** Broadcast the transform type */
-        using transform3 = transform_type;
+        using transform3 = transform_link;
 
         /** Constructor with full arguments
          * 
@@ -32,7 +32,7 @@ namespace detray
          * @param src the source object/source link this surface is representing
          * 
          **/
-        surface(transform_type &&trf, mask_link &&mask, volume_link &&vol, source_link &&src)
+        surface(transform_link &&trf, mask_link &&mask, volume_link &&vol, source_link &&src)
             : _trf(std::move(trf)), _mask(std::move(mask)), _vol(std::move(vol)), _src(std::move(src))
         {
         }
@@ -45,13 +45,13 @@ namespace detray
          * 
          * @param rhs is the right hand side to be compared to 
         */
-        bool operator==(const surface<transform_type, mask_link, source_link> &rhs) const
+        bool operator==(const surface<transform_link, mask_link, source_link> &rhs) const
         {
             return (_trf == rhs.__trf and _mask == rhs._mask and _vol == rhs._vol and _src == rhs._src);
         }
 
         /** Return the transform type */
-        const transform_type &transform() const
+        const transform_link &transform() const
         {
             return _trf;
         }
@@ -87,7 +87,7 @@ namespace detray
         }
 
     private:
-        transform_type _trf;
+        transform_link _trf;
         mask_link _mask;
         volume_link _vol;
         source_link _src;

--- a/core/include/core/track.hpp
+++ b/core/include/core/track.hpp
@@ -14,18 +14,17 @@ namespace detray
 {
 
     /** Track struct for navigation through the detector */
-    template <typename transform_type>
+    template <typename transform_type, typename context_type = bool>
     struct track
     {
         using point3 = typename transform_type::point3;
         using vector3 = typename transform_type::vector3;
-        using context = typename transform_type::context;
 
         point3 pos = {0., 0., 0.};
         vector3 dir = {0., 0., 0.};
         vector3 bfield = {0., 0., 0.};
         scalar momentum = std::numeric_limits<scalar>::infinity();
-        context ctx;
+        context_type ctx;
 
         scalar overstep_tolerance = 0.;
     };

--- a/core/include/geometry/detector.hpp
+++ b/core/include/geometry/detector.hpp
@@ -29,7 +29,6 @@ namespace detray
         // Algebra
         using point3 = typename transform_type::point3;
         using vector3 = typename transform_type::vector3;
-        using context = typename transform_type::context;
         using point2 = __plugin::cartesian2::point2;
         using transform3 = transform_type;
 

--- a/core/include/tools/cylinder_intersector.hpp
+++ b/core/include/tools/cylinder_intersector.hpp
@@ -11,7 +11,6 @@
 #include <optional>
 
 #include "core/intersection.hpp"
-#include "core/surface.hpp"
 #include "core/track.hpp"
 #include "utils/quadratic_equation.hpp"
 #include "utils/unbound.hpp"
@@ -27,13 +26,13 @@ namespace detray
 
         /** Intersection method for cylindrical surfaces
          * 
-         * @tparam surface_type The surface type to be intersected
+         * @tparam transform_type The surface transform type to be intersected
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
          * Contextual part:
-         * @param s the surface to be intersected
-         * @param t the track information
+         * @param trf the transform of the surface to be intersected
+         * @param track the track information
          * @param local to the local local frame 
          * 
          * Non-contextual part:
@@ -41,27 +40,26 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename surface_type, typename local_type, typename mask_type>
-        intersection<scalar, typename surface_type::transform3::point3, typename local_type::point2>
-        intersect(const surface_type &s,
-                  const track<typename surface_type::transform3> &t,
+        template <typename transform_type, typename local_type, typename mask_type>
+        intersection<scalar, typename transform_type::transform3::point3, typename local_type::point2>
+        intersect(const transform_type &trf,
+                  const track<transform_type> &track,
                   const local_type &local,
                   const mask_type &mask) const
         {
-            return intersect(s, t.pos, t.dir, t.ctx, local, mask, t.overstep_tolerance);
+            return intersect(trf, track.pos, track.dir, local, mask, track.overstep_tolerance);
         }
 
         /** Intersection method for cylindrical surfaces
          * 
-         * @tparam surface_type The surface type to be intersected
+         * @tparam transform_type The transform type of the surface  to be intersected
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
          * Contextual part:
-         * @param s the surface to be intersected
+         * @param trf the transform of the surface to be intersected
          * @param ro the origin of the ray
          * @param rd the direction of the ray
-         * @param ctx the context of the call
          * @param local to the local local frame 
          * 
          * Non-contextual part:
@@ -69,29 +67,25 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename surface_type, typename local_type, typename mask_type>
-        intersection<scalar, typename surface_type::transform3::point3, typename local_type::point2>
-        intersect(const surface_type &s,
-                  const typename surface_type::transform3::point3 &ro,
-                  const typename surface_type::transform3::vector3 &rd,
-                  const typename surface_type::transform3::context &ctx,
+        template <typename transform_type, typename local_type, typename mask_type>
+        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        intersect(const transform_type &trf,
+                  const typename transform_type::point3 &ro,
+                  const typename transform_type::vector3 &rd,
                   const local_type &local,
                   const mask_type &mask,
                   scalar overstep_tolerance = 0.) const
         {
-            using point3 = typename surface_type::transform3::point3;
-            using vector3 = typename surface_type::transform3::vector3;
-            using point2 = typename local_type::point2;
-            using intersection = intersection<scalar, point3, point2>;
+            using intersection = intersection<scalar, typename transform_type::point3, typename local_type::point2>;
 
             scalar r = mask[0];
 
-            const auto &m = s.transform().matrix(ctx);
+            const auto &m = trf.matrix();
             auto sz = getter::vector<3>(m, 0, 2);
             auto sc = getter::vector<3>(m, 0, 3);
 
-            vector3 pc_cross_sz = vector::cross(ro - sc, sz);
-            vector3 rd_cross_sz = vector::cross(rd, sz);
+            typename transform_type::vector3 pc_cross_sz = vector::cross(ro - sc, sz);
+            typename transform_type::vector3 rd_cross_sz = vector::cross(rd, sz);
             scalar a = vector::dot(rd_cross_sz, rd_cross_sz);
             double b = 2. * vector::dot(rd_cross_sz, pc_cross_sz);
             double c = vector::dot(pc_cross_sz, pc_cross_sz) - (r * r);
@@ -108,8 +102,8 @@ namespace detray
                     intersection is;
                     is.path = t;
                     is.point3 = ro + is.path * rd;
-                    is.point2 = local(s, is.point3, ctx);
-                    auto local3 = s.transform().point_to_local(is.point3, ctx);
+                    is.point2 = local(trf, is.point3);
+                    auto local3 = trf.point_to_local(is.point3);
                     is.status = mask(local3);
                     scalar rdr = getter::perp(local3 + 10 * std::numeric_limits<scalar>::epsilon() * rd);
                     is.direction = rdr > r ? e_along : e_opposite;

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -105,7 +105,7 @@ namespace detray
             {
                 auto &mask = masks[i];
                 auto is = mask.intersector();
-                sfi = is.intersect(surface, track, local, mask);
+                sfi = is.intersect(surface.transform(), track, local, mask);
                 if (sfi.status == e_inside)
                 {
                     links = mask.links();

--- a/core/include/tools/planar_intersector.hpp
+++ b/core/include/tools/planar_intersector.hpp
@@ -26,13 +26,13 @@ namespace detray
 
         /** Intersection method for planar surfaces
          * 
-         * @tparam surface_type The surface type to be intersected
+         * @tparam transform_type The transform type of the surface to be intersected
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
          * Contextual part:
-         * @param s the surface to be intersected
-         * @param t the track information
+         * @param trf the surface to be intersected
+         * @param track the track information
          * @param local to the local frame 
          * 
          * Non-contextual part:
@@ -40,51 +40,47 @@ namespace detray
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename surface_type, typename local_type, typename mask_type>
-        intersection<scalar, typename surface_type::transform3::point3, typename local_type::point2>
-        intersect(const surface_type &s,
-                  const track<typename surface_type::transform3> &t,
+        template <typename transform_type, typename local_type, typename mask_type>
+        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        intersect(const transform_type &trf,
+                  const track<transform_type> &track,
                   const local_type &local,
                   const mask_type &mask) const
         {
-            return intersect(s, t.pos, t.dir, t.ctx, local, mask, t.overstep_tolerance);
+            return intersect(trf, track.pos, track.dir, local, mask, track.overstep_tolerance);
         }
 
         /** Intersection method for planar surfaces
          * 
-         * @tparam surface_type The surface type to be intersected
+         * @tparam transform_type The type of the transform ot the surface to be intersected
          * @tparam local_type The local frame type to be intersected
          * @tparam mask_type The mask type applied to the local frame
          * 
          * Contextual part:
-         * @param s the surface to be intersected
+         * @param trf the transform of the surface to be intersected
          * @param ro the origin of the ray
          * @param rd the direction of the ray
-         * @param ctx the context of the call
-         * @param local to the local local frame 
+         * @param local transform to the local local frame 
          * 
          * Non-contextual part:
          * @param mask the local mask 
          * 
          * @return the intersection with optional parameters
          **/
-        template <typename surface_type, typename local_type = unbound, typename mask_type = unmasked<>>
-        intersection<scalar, typename surface_type::transform3::point3, typename local_type::point2>
-        intersect(const surface_type &s,
-                  const typename surface_type::transform3::point3 &ro,
-                  const typename surface_type::transform3::vector3 &rd,
-                  const typename surface_type::transform3::context &ctx,
+        template <typename transform_type, typename local_type = unbound, typename mask_type = unmasked<>>
+        intersection<scalar, typename transform_type::point3, typename local_type::point2>
+        intersect(const transform_type &trf,
+                  const typename transform_type::point3 &ro,
+                  const typename transform_type::vector3 &rd,
                   const local_type &local = local_type(),
                   const mask_type &mask = mask_type(),
                   scalar overstep_tolerance = 0.) const
         {
 
-            using point3 = typename surface_type::transform3::point3;
-            using point2 = typename local_type::point2;
-            using intersection = intersection<scalar, point3, point2>;
+            using intersection = intersection<scalar, typename transform_type::point3, typename local_type::point2>;
 
             // Retrieve the surface normal & translation (context resolved)
-            const auto &sm = s.transform().matrix(ctx);
+            const auto &sm = trf.matrix();
             auto sn = getter::vector<3>(sm, 0, 2);
             auto st = getter::vector<3>(sm, 0, 3);
 
@@ -95,8 +91,8 @@ namespace detray
                 intersection is;
                 is.path = vector::dot(sn, (st - ro)) / (denom);
                 is.point3 = ro + is.path * rd;
-                is.point2 = local(s, is.point3, ctx);
-                is.status = mask(is.point2.value_or(point2()));
+                is.point2 = local(trf, is.point3);
+                is.status = mask(is.point2.value_or(typename local_type::point2()));
                 is.direction = denom > 0 ? e_along : e_opposite;
                 return is;
             }

--- a/core/include/utils/unbound.hpp
+++ b/core/include/utils/unbound.hpp
@@ -11,8 +11,7 @@
 namespace detray
 {
 
-    /** A representation that is not bound to a local frame
-         */
+    /** A representation that is not bound to a local frame */
     struct unbound
     {
         using point2 = int;
@@ -23,10 +22,9 @@ namespace detray
               * @tparam the type of the surface from which also point3 and context type can be deduced
               * 
               */
-        template <typename surface_type>
-        const std::optional<point2> operator()(const surface_type & /*ignored*/,
-                                               const typename surface_type::transform3::point3 & /*ignored*/,
-                                               const typename surface_type::transform3::context & /*ignored*/) const
+        template <typename transform_type>
+        const std::optional<point2> operator()(const transform_type & /*ignored*/,
+                                               const typename transform_type::point3 & /*ignored*/) const
         {
             return std::nullopt;
         }

--- a/plugins/array/include/plugins/array_defs.hpp
+++ b/plugins/array/include/plugins/array_defs.hpp
@@ -60,7 +60,6 @@ namespace detray
         return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
     }
 
-    // first occurance of namespace vector
     namespace vector
     {
         /** Cross product between two input vectors - 3 Dim
@@ -184,21 +183,20 @@ namespace detray
         {
             using vector3 = std::array<scalar, 3>;
             using point3 = vector3;
-            using context = std::any;
 
             using matrix44 = std::array<std::array<scalar, 4>, 4>;
 
             matrix44 _data;
             matrix44 _data_inv;
 
-            /** Contructor with arguments: t, z, x, ctx
+            /** Contructor with arguments: t, z, x
              * 
              * @param t the translation (or origin of the new frame)
              * @param z the z axis of the new frame, normal vector for planes
              * @param x the x axis of the new frame
              * 
              **/
-            transform3(const vector3 &t, const vector3 &z, const vector3 &x, const context & /*ctx*/)
+            transform3(const vector3 &t, const vector3 &z, const vector3 &x)
             {
                 auto y = vector::cross(z, x);
                 _data[0][0] = x[0];
@@ -225,7 +223,7 @@ namespace detray
              *
              * @param t is the transform
              **/
-            transform3(const vector3 &t, const context & /*ctx*/)
+            transform3(const vector3 &t)
             {
                 _data[0][0] = 1.;
                 _data[0][1] = 0.;
@@ -251,7 +249,7 @@ namespace detray
              * 
              * @param m is the full 4x4 matrix 
              **/
-            transform3(const matrix44 &m, const context & /*ctx*/)
+            transform3(const matrix44 &m)
             {
                 _data = m;
             }
@@ -260,7 +258,7 @@ namespace detray
              * 
              * @param ma is the full 4x4 matrix 16 array
              **/
-            transform3(const std::array<scalar, 16> &ma, const context & /*ctx*/)
+            transform3(const std::array<scalar, 16> &ma)
             {
                 _data[0][0] = ma[0];
                 _data[0][1] = ma[4];
@@ -382,104 +380,80 @@ namespace detray
                                m[0][2] * v[0] + m[1][2] * v[1] + m[2][2] * v[2]};
             }
 
-            /** This method retrieves the rotation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto rotation(const context & /*ctx*/) const
+            /** This method retrieves the rotation of a transform */
+            auto rotation() const
             {
                 return getter::block<3, 3>(_data, 0, 0);
             }
 
-            /** This method retrieves the translation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            point3 translation(const context & /*ctx*/) const
+            /** This method retrieves the translation of a transform */
+            point3 translation() const
             {
                 return point3{_data[3][0], _data[3][1], _data[3][2]};
             }
 
-            /** This method retrieves the 4x4 matrix of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            const matrix44 &matrix(const context & /*ctx*/) const
+            /** This method retrieves the 4x4 matrix of a transform */
+            const matrix44 &matrix() const
             {
                 return _data;
             }
 
-            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame */
             template <typename point_type>
-            const point_type point_to_global(const point_type &v, const array::transform3::context & /*ctx*/) const
+            const point_type point_to_global(const point_type &v) const
             {
                 vector3 rg = rotate(_data, v);
                 return point3{rg[0] + _data[3][0], rg[1] + _data[3][1], rg[2] + _data[3][2]};
             }
 
-            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame */
             template <typename point_type>
-            const point_type point_to_local(const point_type &v, const array::transform3::context & /*ctx*/) const
+            const point_type point_to_local(const point_type &v) const
             {
                 vector3 rg = rotate(_data_inv, v);
                 return point3{rg[0] + _data_inv[3][0], rg[1] + _data_inv[3][1], rg[2] + _data_inv[3][2]};
             }
 
-            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame */
             template <typename vector_type>
-            const vector_type vector_to_global(const vector_type &v, const array::transform3::context & /*ctx*/) const
+            const vector_type vector_to_global(const vector_type &v) const
             {
                 return rotate(_data, v);
             }
 
-            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame */
             template <typename vector_type>
-            const auto vector_to_local(const vector_type &v, const array::transform3::context & /*ctx*/) const
+            const auto vector_to_local(const vector_type &v) const
             {
                 return rotate(_data_inv, v);
             }
         };
 
-        /** Non-contextual local frame projection into a cartesian coordinate frame
+        /** Frame projection into a cartesian coordinate frame
          */
         struct cartesian2
         {
             using point2 = std::array<scalar, 2>;
             using point3 = std::array<scalar, 3>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            point2 operator()(const surface_type &s,
-                              const typename surface_type::transform3::point3 &p,
-                              const typename surface_type::transform3::context &ctx) const
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            point2 operator()(const transform3 &trf,
+                                  const transform3::point3 &p) const
             {
-                return operator()(s.transform().point_to_local(p, ctx));
+                return operator()(trf.point_to_local(p));
             }
 
             /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             *
+             * @param v the point in local frame
+             * 
+             * @return a local point2
              */
             point2 operator()(const point3 &v) const
             {
@@ -487,25 +461,23 @@ namespace detray
             }
         };
 
-        /** Non-contextual local frame projection into a polar coordinate frame
-         **/
+        /** Local frame projection into a polar coordinate frame */
         struct polar2
         {
             using point2 = std::array<scalar, 2>;
             using point3 = std::array<scalar, 3>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            point2 operator()(const surface_type &s,
-                              const typename surface_type::transform3::point3 &p,
-                              const typename surface_type::transform3::context &ctx) const
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            point2 operator()(const transform3 &trf,
+                                  const transform3::point3 &p) const
             {
-                return operator()(s.transform().point_to_local(p, ctx));
+                return operator()(trf.point_to_local(p));
             }
 
             /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point */
@@ -516,29 +488,27 @@ namespace detray
             }
         };
 
-        /** Non-contextual local frame projection into a polar coordinate frame
-         **/
+        /** Local frame projection into a polar coordinate frame */
         struct cylindrical2
         {
             using point2 = std::array<scalar, 2>;
             using point3 = std::array<scalar, 3>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
+             /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            point2 operator()(const transform3 &trf,
+                                  const transform3::point3 &p) const
             {
-                return operator()(s.transform().point_to_local(p, ctx));
+                return operator()(trf.point_to_local(p));
             }
 
             /** This method transform from a point from 2 3D cartesian frame to a 2D cylindrical point */
-            auto operator()(const point3 &v) const
+            point2 operator()(const point3 &v) const
             {
                 return point2{getter::perp(v) * getter::phi(v), v[2]};
             }
@@ -546,7 +516,7 @@ namespace detray
 
     } // namespace array
 
-    // Non-contextual vector transfroms
+    // Vector transfroms
     namespace vector
     {
 

--- a/plugins/eigen/include/plugins/eigen_defs.hpp
+++ b/plugins/eigen/include/plugins/eigen_defs.hpp
@@ -107,14 +107,11 @@ namespace detray
     // eigen definitions
     namespace eigen
     {
-        /** Transform wrapper class to ensure standard API within differnt plugins
-         * 
-         **/
+        /** Transform wrapper class to ensure standard API within differnt plugins */
         struct transform3
         {
             using vector3 = Eigen::Matrix<scalar, 3, 1>;
             using point3 = vector3;
-            using context = std::any;
 
             Eigen::Transform<scalar, 3, Eigen::Affine> _data =
                 Eigen::Transform<scalar, 3, Eigen::Affine>::Identity();
@@ -124,14 +121,14 @@ namespace detray
 
             using matrix44 = Eigen::Transform<scalar, 3, Eigen::Affine>::MatrixType;
 
-            /** Contructor with arguments: t, z, x, ctx
+            /** Contructor with arguments: t, z, x
              * 
              * @param t the translation (or origin of the new frame)
              * @param z the z axis of the new frame, normal vector for planes
              * @param x the x axis of the new frame
              * 
              **/
-            transform3(const vector3 &t, const vector3 &z, const vector3 &x, const context & /*ctx*/)
+            transform3(const vector3 &t, const vector3 &z, const vector3 &x)
             {
                 auto y = z.cross(x);
 
@@ -148,7 +145,7 @@ namespace detray
              *
              * @param t is the transform
              **/
-            transform3(const vector3 &t, const context & /*ctx*/)
+            transform3(const vector3 &t)
             {
                 auto &matrix = _data.matrix();
                 matrix.block<3, 1>(0, 3) = t;
@@ -160,7 +157,7 @@ namespace detray
              * 
              * @param m is the full 4x4 matrix 
              **/
-            transform3(const matrix44 &m, const context & /*ctx*/)
+            transform3(const matrix44 &m)
             {
                 _data.matrix() = m;
 
@@ -171,7 +168,7 @@ namespace detray
              * 
              * @param ma is the full 4x4 matrix asa 16 array
              **/
-            transform3(const darray<scalar, 16> &ma, const context & /*ctx*/)
+            transform3(const darray<scalar, 16> &ma)
             {
                 _data.matrix() << ma[0], ma[1], ma[2], ma[3], ma[4], ma[5], ma[6], ma[7],
                     ma[8], ma[9], ma[10], ma[11], ma[12], ma[13], ma[14], ma[15];
@@ -190,45 +187,27 @@ namespace detray
                 return (_data.isApprox(rhs._data));
             }
 
-            /** This method retrieves the rotation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto rotation(const context & /*ctx*/) const
+            /** This method retrieves the rotation of a transform  **/
+            auto rotation() const
             {
                 return _data.matrix().block<3, 3>(0, 0);
             }
 
-            /** This method retrieves the translation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto translation(const context & /*ctx*/) const
+            /** This method retrieves the translation of a transform **/
+            auto translation() const
             {
                 return _data.matrix().block<3, 1>(0, 3);
             }
 
-            /** This method retrieves the 4x4 matrix of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            const auto &matrix(const context & /*ctx*/) const
+            /** This method retrieves the 4x4 matrix of a transform */
+            const auto &matrix() const
             {
                 return _data.matrix();
             }
 
-            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame */
             template <typename derived_type>
-            auto point_to_global(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/) const
+            auto point_to_global(const Eigen::MatrixBase<derived_type> &v) const
             {
                 constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
                 constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
@@ -236,12 +215,9 @@ namespace detray
                 return (_data * v);
             }
 
-            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame */
             template <typename derived_type>
-            auto point_to_local(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/) const
+            auto point_to_local(const Eigen::MatrixBase<derived_type> &v) const
             {
                 constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
                 constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
@@ -249,12 +225,9 @@ namespace detray
                 return (_data_inv * v);
             }
 
-            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame */
             template <typename derived_type>
-            auto vector_to_global(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/) const
+            auto vector_to_global(const Eigen::MatrixBase<derived_type> &v) const
             {
                 constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
                 constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
@@ -262,12 +235,9 @@ namespace detray
                 return (_data.linear() * v);
             }
 
-            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame */
             template <typename derived_type>
-            auto vector_to_local(const Eigen::MatrixBase<derived_type> &v, const eigen::transform3::context & /*ctx*/) const
+            auto vector_to_local(const Eigen::MatrixBase<derived_type> &v) const
             {
                 constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
                 constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
@@ -276,27 +246,17 @@ namespace detray
             }
         };
 
-        /** Non-contextual local frame projection into a cartesian coordinate frame
+        /** Local frame projection into a cartesian coordinate frame
          */
         struct cartesian2
         {
             using point2 = Eigen::Matrix<scalar, 2, 1>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
-            {
-                return operator()(s.transform().point_to_local(p, ctx));
-            }
-
             /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             *
+             * @param v the point in local frame
+             * 
+             * @return a local point2
              */
             template <typename derived_type>
             auto operator()(const Eigen::MatrixBase<derived_type> &v) const
@@ -306,62 +266,68 @@ namespace detray
                 static_assert(rows == 3 and cols == 1, "transform::point3_topoint2(v) requires a (3,1) matrix");
                 return (v.template segment<2>(0)).eval();
             }
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            auto operator()(const transform3 &trf,
+                            const transform3::point3 &p) const
+            {
+                return operator()(trf.point_to_local(p));
+            }
         };
 
-        /** Non-contextual local frame projection into a polar coordinate frame
-         **/
+        /** Local frame projection into a polar coordinate frame */
         struct polar2
         {
             using point2 = Eigen::Matrix<scalar, 2, 1>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
-            {
-                return operator()(s.transform().point_to_local(p, ctx));
-            }
-
-            /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point */
+            /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point
+             *              
+             * @param v the point in local frame
+             * 
+             * @return a local point2
+             */
             template <typename derived_type>
-            const auto operator()(const Eigen::MatrixBase<derived_type> &v) const
+            auto operator()(const Eigen::MatrixBase<derived_type> &v) const
             {
                 constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
                 constexpr int cols = Eigen::MatrixBase<derived_type>::ColsAtCompileTime;
                 static_assert(rows >= 2 and cols == 1, "transform::point_topoint2pol(v) requires a (>2,1) matrix");
                 return point2{getter::perp(v), getter::phi(v)};
             }
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            auto operator()(const transform3 &trf,
+                            const transform3::point3 &p) const
+            {
+                return operator()(trf.point_to_local(p));
+            }
         };
 
-        /** Non-contextual local frame projection into a polar coordinate frame
-         **/
+        /** Local frame projection into a polar coordinate frame */
         struct cylindrical2
         {
             using point2 = Eigen::Matrix<scalar, 2, 1>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
-            {
-                return operator()(s.transform().point_to_local(p, ctx));
-            }
-
-            /** This method transform from a point from 2 3D cartesian frame to a 2D cylindrical point */
+            /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point
+             *              
+             * @param v the point in local frame
+             * 
+             * @return a local point2
+             */
             template <typename derived_type>
-            const auto operator()(const Eigen::MatrixBase<derived_type> &v) const
+            auto operator()(const Eigen::MatrixBase<derived_type> &v) const
             {
 
                 constexpr int rows = Eigen::MatrixBase<derived_type>::RowsAtCompileTime;
@@ -369,11 +335,24 @@ namespace detray
                 static_assert(rows == 3 and cols == 1, "transform::point3_topoint2cyl(v) requires a a (3,1) matrix");
                 return point2{getter::perp(v) * getter::phi(v), v[2]};
             }
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            auto operator()(const transform3 &trf,
+                            const transform3::point3 &p) const
+            {
+                return operator()(trf.point_to_local(p));
+            }
         };
 
     } // namespace eigen
 
-    // Non-contextual vector transfroms
+    // Vector transfroms
     namespace vector
     {
 

--- a/plugins/smatrix/include/plugins/smatrix_defs.hpp
+++ b/plugins/smatrix/include/plugins/smatrix_defs.hpp
@@ -78,7 +78,7 @@ namespace detray
             static_assert(kDIM >= 2, "vector::perp() required rows >= 2.");
             return std::sqrt(v[0] * v[0] + v[1] * v[1]);
         }
-        
+
         /** This method retrieves a column from a matrix
          * 
          * @param m the input matrix 
@@ -86,7 +86,7 @@ namespace detray
         template <unsigned int kROWS, typename matrix_type>
         auto vector(const matrix_type &m, unsigned int row, unsigned int col)
         {
-            return m.template SubCol<SVector<scalar, kROWS> > (col, row);
+            return m.template SubCol<SVector<scalar, kROWS>>(col, row);
         }
 
         /** This method retrieves a column from a matrix
@@ -96,7 +96,7 @@ namespace detray
         template <unsigned int kROWS, unsigned int kCOLS, typename matrix_type>
         auto block(const matrix_type &m, unsigned int row, unsigned int col)
         {
-            return m.template Sub <SMatrix<scalar, kROWS, kCOLS> >(row, col);
+            return m.template Sub<SMatrix<scalar, kROWS, kCOLS>>(row, col);
         }
 
     } // namespace getter
@@ -111,7 +111,6 @@ namespace detray
         {
             using vector3 = SVector<scalar, 3>;
             using point3 = vector3;
-            using context = std::any;
 
             SMatrix<scalar, 4, 4> _data = ROOT::Math::SMatrixIdentity();
             SMatrix<scalar, 4, 4> _data_inv = ROOT::Math::SMatrixIdentity();
@@ -119,14 +118,14 @@ namespace detray
             using matrix44 = decltype(_data);
             using matrix33 = SMatrix<scalar, 3, 3>;
 
-            /** Contructor with arguments: t, z, x, ctx
+            /** Contructor with arguments: t, z, x
              * 
              * @param t the translation (or origin of the new frame)
              * @param z the z axis of the new frame, normal vector for planes
              * @param x the x axis of the new frame
              * 
              **/
-            transform3(const vector3 &t, const vector3 &z, const vector3 &x, const context & /*ctx*/)
+            transform3(const vector3 &t, const vector3 &z, const vector3 &x)
             {
                 auto y = Cross(z, x);
                 _data(0, 0) = x[0];
@@ -141,7 +140,7 @@ namespace detray
                 _data(0, 3) = t[0];
                 _data(1, 3) = t[1];
                 _data(2, 3) = t[2];
-                
+
                 int ifail = 0;
                 _data_inv = _data.Inverse(ifail);
                 // This should be an exception, "transform3 could not be initialized. Matrix not invertible."
@@ -152,12 +151,12 @@ namespace detray
              *
              * @param t is the translation
              **/
-            transform3(const vector3 &t, const context & /*ctx*/)
+            transform3(const vector3 &t)
             {
                 _data(0, 3) = t[0];
                 _data(1, 3) = t[1];
                 _data(2, 3) = t[2];
-                
+
                 int ifail = 0;
                 _data_inv = _data.Inverse(ifail);
                 // This should be an exception, "transform3 could not be initialized. Matrix not invertible."
@@ -168,11 +167,11 @@ namespace detray
              * 
              * @param m is the full 4x4 matrix 
              **/
-            transform3(const matrix44 &m, const context & /*ctx*/)
+            transform3(const matrix44 &m)
             {
                 _data = m;
-                
-               int ifail = 0;
+
+                int ifail = 0;
                 _data_inv = _data.Inverse(ifail);
                 // This should be an exception, "transform3 could not be initialized. Matrix not invertible."
                 assert(ifail == 0);
@@ -182,7 +181,7 @@ namespace detray
              * 
              * @param ma is the full 4x4 matrix asa 16 array
              **/
-            transform3(const std::array<scalar, 16> &ma, const context & /*ctx*/)
+            transform3(const std::array<scalar, 16> &ma)
             {
 
                 _data(0, 0) = ma[0];
@@ -201,7 +200,7 @@ namespace detray
                 _data(1, 3) = ma[7];
                 _data(2, 3) = ma[11];
                 _data(3, 3) = ma[15];
-                
+
                 int ifail = 0;
                 _data_inv = _data.Inverse(ifail);
                 // This should be an exception, "transform3 could not be initialized. Matrix not invertible."
@@ -212,185 +211,159 @@ namespace detray
             transform3(const transform3 &rhs) = default;
             ~transform3() = default;
 
-            /** This method retrieves the rotation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto rotation(const context & /*ctx*/) const
+            /** This method retrieves the rotation of a transform */
+            auto rotation() const
             {
-                return (_data.Sub<SMatrix<scalar, 3, 3> >(0, 0));
+                return (_data.Sub<SMatrix<scalar, 3, 3>>(0, 0));
             }
 
-            /** This method retrieves the translation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto translation(const context & /*ctx*/) const
+            /** This method retrieves the translation of a transform */
+            auto translation() const
             {
-                return (_data.SubCol<SVector<scalar, 3> >(3, 0));
+                return (_data.SubCol<SVector<scalar, 3>>(3, 0));
             }
 
-            /** This method retrieves the 4x4 matrix of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto matrix(const context & /*ctx*/) const
+            /** This method retrieves the 4x4 matrix of a transform */
+            auto matrix() const
             {
                 return _data;
             }
-                     
-            /** This method retrieves the translation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto translation_inv(const context & /*ctx*/) const
+
+            /** This method retrieves the translation of a transform */
+            auto translation_inv() const
             {
-                return (_data_inv.SubCol<SVector<scalar, 3> >(3, 0));
-            }
-            
-            /** This method retrieves the rotation of a transform
-             * 
-             * @param ctx the context object
-             * 
-             * @note this is a contextual method
-             **/
-            auto rotation_inv(const context & /*ctx*/) const
-            {
-                return (_data_inv.Sub<SMatrix<scalar, 3, 3> >(0, 0));
+                return (_data_inv.SubCol<SVector<scalar, 3>>(3, 0));
             }
 
-            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
-            const point3 point_to_global(const point3 &v, const smatrix::transform3::context & ctx) const
+            /** This method retrieves the rotation of a transform */
+            auto rotation_inv() const
             {
-                return translation(ctx) + (rotation_inv(ctx) * v);
+                return (_data_inv.Sub<SMatrix<scalar, 3, 3>>(0, 0));
             }
 
-            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
-            const point3 point_to_local(const point3 &v, const smatrix::transform3::context & ctx) const
+            /** This method transform from a point from the local 3D cartesian frame to the global 3D cartesian frame */
+            const point3 point_to_global(const point3 &v) const
             {
-                return translation_inv(ctx) + (rotation_inv(ctx) * v);
+                return translation() + (rotation_inv() * v);
             }
 
-            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
-            const point3 vector_to_global(const vector3 &v, const smatrix::transform3::context & ctx) const
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame */
+            const point3 point_to_local(const point3 &v) const
             {
-                return rotation(ctx) * v;
+                return translation_inv() + (rotation_inv() * v);
             }
 
-            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame
-             * 
-             * @note this is a contextual method 
-             **/
-            const point3 vector_to_local(const vector3 &v, const smatrix::transform3::context & ctx) const
+            /** This method transform from a vector from the local 3D cartesian frame to the global 3D cartesian frame */
+            const point3 vector_to_global(const vector3 &v) const
             {
-                return rotation_inv(ctx) * v;
+                return rotation() * v;
+            }
+
+            /** This method transform from a vector from the global 3D cartesian frame into the local 3D cartesian frame */
+            const point3 vector_to_local(const vector3 &v) const
+            {
+                return rotation_inv() * v;
             }
         };
 
-        /** Non-contextual local frame projection into a cartesian coordinate frame
-         */
+        /** Local frame projection into a cartesian coordinate frame */
         struct cartesian2
         {
             using point2 = SVector<scalar, 2>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             *
+             * @param v the point in local frame
+             * 
+             * @return a local point2
+             */
+            template <typename point3_type>
+            const auto operator()(const point3_type &v) const
             {
-                return operator()(s.transform().point_to_local(p, ctx));
+                return v.template Sub<SVector<scalar, 2>>(0);
             }
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
-             */
-            template<typename point3_type> const auto operator()(const point3_type &v) const
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            const auto operator()(const transform3 &trf,
+                                  const transform3::point3 &p) const
             {
-                return v.template Sub<SVector<scalar, 2> >(0);
+                return operator()(trf.point_to_local(p));
             }
         };
 
-        /** Non-contextual local frame projection into a polar coordinate frame
+        /** Local frame projection into a polar coordinate frame
          **/
         struct polar2
         {
             using point2 = SVector<scalar, 2>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
-            {
-                return operator()(s.transform().point_to_local(p, ctx));
-            }
-
-            /** This method transform from a point from 2D or 3D cartesian frame to a 2D polar point */
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             *
+             * @param v the point in local frame
+             * 
+             * @return a local point2
+             */
             template <typename point3_type>
             const auto operator()(const point3_type &v) const
             {
                 return point2{getter::perp(v), getter::phi(v)};
             }
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            const auto operator()(const transform3 &trf,
+                                  const transform3::point3 &p) const
+            {
+                return operator()(trf.point_to_local(p));
+            }
         };
 
-        /** Non-contextual local frame projection into a polar coordinate frame
+        /** Local frame projection into a polar coordinate frame
          **/
         struct cylindrical2
         {
             using point2 = SVector<scalar, 2>;
 
-            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame,
-              * including the contextual transform into the local 3D frame
-              * 
-              * @tparam the type of the surface from which also point3 and context type can be deduced
-              * 
-              */
-            template <typename surface_type>
-            const auto operator()(const surface_type &s,
-                                  const typename surface_type::transform3::point3 &p,
-                                  const typename surface_type::transform3::context &ctx) const
-            {
-                return operator()(s.transform().point_to_local(p, ctx));
-            }
-
-            /** This method transform from a point from 2 3D cartesian frame to a 2D cylindrical point */
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame
+             *
+             * @param v the point in local frame
+             * 
+             * @return a local point2
+             */
             template <typename point3_type>
             const auto operator()(const point3_type &v) const
             {
                 return point2{getter::perp(v) * getter::phi(v), v[2]};
             }
+
+            /** This method transform from a point from the global 3D cartesian frame to the local 2D cartesian frame 
+             * 
+             * @param trf the transform from global to local thredimensional frame
+             * @param p the point in global frame
+             * 
+             * @return a local point2
+             **/
+            const auto operator()(const transform3 &trf,
+                                  const transform3::point3 &p) const
+            {
+                return operator()(trf.point_to_local(p));
+            }
         };
 
-    } // namespace eigen
+    } // namespace smatrix
 
-    // Non-contextual vector transfroms
+    // Vector transfroms
     namespace vector
     {
 
@@ -415,7 +388,7 @@ namespace detray
          * @param b the second input vector
          * 
          * @return the scalar dot product value 
-         **/        
+         **/
         template <typename vector3_type, typename vecexpr3_type>
         auto dot(const vector3_type &a, const vecexpr3_type &b)
         {

--- a/tests/common/include/tests/common/benchmark_intersect_all.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_all.inl
@@ -18,7 +18,6 @@ using namespace detray;
 using transform3 = __plugin::transform3;
 using point3 = transform3::point3;
 using vector3 = transform3::vector3;
-using context = transform3::context;
 using surface = surface<transform3>;
 
 __plugin::cartesian2 cartesian2;
@@ -59,7 +58,6 @@ namespace __plugin
         unsigned int hits_inside = 0;
         unsigned int hits_outside = 0;
         unsigned int hits_missed = 0;
-        context ctx;
 
         point3 ori = {0., 0., 0.};
 
@@ -95,12 +93,12 @@ namespace __plugin
                                 if (group_index == 0)
                                 {
                                     auto mask = std::get<0>(layer.masks)[mask_index];
-                                    hit = mask.intersector().intersect(surface, ori, dir, ctx, cartesian2, mask);
+                                    hit = mask.intersector().intersect(surface.transform(), ori, dir, cartesian2, mask);
                                 }
                                 else
                                 {
                                     auto mask = std::get<1>(layer.masks)[mask_index];
-                                    hit = mask.intersector().intersect(surface, ori, dir, ctx, cartesian2, mask);
+                                    hit = mask.intersector().intersect(surface.transform(), ori, dir, cartesian2, mask);
                                 }
 
                                 if (hit.status == e_inside)

--- a/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
+++ b/tests/common/include/tests/common/benchmark_intersect_surfaces.inl
@@ -22,7 +22,6 @@ using namespace detray;
 using transform3 = __plugin::transform3;
 using point3 = transform3::point3;
 using vector3 = transform3::vector3;
-using context = transform3::context;
 using plane_surface = surface<transform3>;
 __plugin::cartesian2 cart2;
 __plugin::cylindrical2 cyl2;
@@ -44,9 +43,6 @@ namespace __plugin
         unsigned int sfmiss = 0;
 
         rectangle2<scalar> rect = {10., 20.};
-
-        context ctx;
-
         point3 ori = {0., 0., 0.};
 
         for (auto _ : state)
@@ -70,7 +66,7 @@ namespace __plugin
                     for (auto plane : planes)
                     {
                         auto pi = rect.intersector();
-                        auto is = pi.intersect(plane, ori, dir, ctx, cart2, rect);
+                        auto is = pi.intersect(plane.transform(), ori, dir, cart2, rect);
                         if (is.status == e_inside)
                         {
                             ++sfhit;
@@ -101,7 +97,6 @@ namespace __plugin
             cylinders.push_back(cylinder_mask{r, -10., 10.});
         }
 
-        context ctx;
         surface<transform3> plain(std::move(transform3()), 0, 0, false);
 
         point3 ori = {0., 0., 0.};
@@ -127,7 +122,7 @@ namespace __plugin
                     for (auto cylinder : cylinders)
                     {
                         auto ci = cylinder.intersector();
-                        auto is = ci.intersect(plain, ori, dir, ctx, cyl2, cylinder);
+                        auto is = ci.intersect(plain.transform(), ori, dir, cyl2, cylinder);
                         if (is.status == e_inside)
                         {
                             ++sfhit;
@@ -157,7 +152,6 @@ namespace __plugin
             cylinders.push_back(cylinder_mask{r, -10., 10.});
         }
 
-        context ctx;
         surface<transform3> plain(std::move(transform3()), 0, 0, false);
 
         point3 ori = {0., 0., 0.};
@@ -183,7 +177,7 @@ namespace __plugin
                     for (auto cylinder : cylinders)
                     {
                         auto cci = cylinder.intersector();
-                        auto is = cci.intersect(plain, ori, dir, ctx, cyl2, cylinder);
+                        auto is = cci.intersect(plain.transform(), ori, dir, cyl2, cylinder);
                         if (is.status == e_inside)
                         {
                             ++sfhit;

--- a/tests/common/include/tests/common/test_core.inl
+++ b/tests/common/include/tests/common/test_core.inl
@@ -23,21 +23,18 @@ using point2 = __plugin::cartesian2::point2;
 using transform3 = __plugin::transform3;
 using vector3 = __plugin::transform3::vector3;
 using point3 = __plugin::transform3::point3;
-using context = __plugin::transform3::context;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 
 // This tests the construction of a surface
 TEST(__plugin, surface)
 {
-    context ctx;
-
     // Preparatioon work, create a transform
     vector3 z = vector::normalize(vector3(3., 2., 1.));
     vector3 x = vector::normalize(vector3(2., -3., 0.));
     vector3 y = vector::cross(z, x);
     point3 t(2., 3., 4.);
-    transform3 trf(t, z, x, ctx);
+    transform3 trf(t, z, x);
 
     surface s(std::move(trf), -1, -1, false);
 }
@@ -52,7 +49,7 @@ TEST(__plugin, intersection)
     intersection i1 = {1.7, point3(0.2, 0.3, 0.), point2(0.2, 0.4), intersection_status::e_inside};
 
     intersection invalid;
-    ASSERT_TRUE(invalid.status== intersection_status::e_missed);
+    ASSERT_TRUE(invalid.status == intersection_status::e_missed);
 
     dvector<intersection> intersections = {invalid, i0, i1};
     std::sort(intersections.begin(), intersections.end());

--- a/tests/common/include/tests/common/test_cylinder_intersection.inl
+++ b/tests/common/include/tests/common/test_cylinder_intersection.inl
@@ -5,7 +5,6 @@
  * Mozilla Public License Version 2.0
  */
 
-#include "core/surface.hpp"
 #include "core/intersection.hpp"
 #include "masks/cylinder3.hpp"
 #include "masks/single3.hpp"
@@ -25,7 +24,6 @@ using namespace detray;
 using transform3 = __plugin::transform3;
 using vector3 = __plugin::transform3::vector3;
 using point3 = __plugin::transform3::point3;
-using context = __plugin::transform3::context;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar isclose = 1e-5;
@@ -33,18 +31,14 @@ constexpr scalar isclose = 1e-5;
 // This defines the local frame test suite
 TEST(__plugin, translated_cylinder)
 {
-    context ctx;
-    using cylinder_surface = surface<transform3, int, int>;
-
     // Create a shifted plane
-    transform3 shifted(vector3{3., 2., 10.}, ctx);
-    cylinder_surface shifted_cylinder(std::move(shifted), 1, 1, false);
+    transform3 shifted(vector3{3., 2., 10.});
     cylinder3<scalar> cylinder = {4., -10., 10.};
     cylinder_intersector ci;
 
     // Unbound local frame test
     unbound ub;
-    auto hit_unbound = ci.intersect(shifted_cylinder, point3{3., 2., 5.}, vector3{1., 0., 0.}, ctx, ub, cylinder);
+    auto hit_unbound = ci.intersect(shifted, point3{3., 2., 5.}, vector3{1., 0., 0.}, ub, cylinder);
     ASSERT_TRUE(hit_unbound.status== intersection_status::e_inside);
     ASSERT_NEAR(hit_unbound.point3[0], 7., epsilon);
     ASSERT_NEAR(hit_unbound.point3[1], 2., epsilon);
@@ -53,7 +47,7 @@ TEST(__plugin, translated_cylinder)
 
     // The same but bound
     __plugin::cylindrical2 cylindrical2;
-    auto hit_bound = ci.intersect(shifted_cylinder, point3{3., 2., 5.}, vector3{1., 0., 0.}, ctx, cylindrical2, cylinder);
+    auto hit_bound = ci.intersect(shifted, point3{3., 2., 5.}, vector3{1., 0., 0.}, cylindrical2, cylinder);
     ASSERT_TRUE(hit_bound.status== intersection_status::e_inside);
     ASSERT_NEAR(hit_bound.point3[0], 7., epsilon);
     ASSERT_NEAR(hit_bound.point3[1], 2., epsilon);
@@ -66,14 +60,12 @@ TEST(__plugin, translated_cylinder)
 // This defines the local frame test suite
 TEST(__plugin, concentric_cylinders)
 {
-    context ctx;
     using cylinder_surface = surface<transform3, int, int>;
 
     // Create a shifted plane
     scalar r = 4.;
     scalar hz = 10.;
-    transform3 identity(vector3{0., 0., 0.}, ctx);
-    cylinder_surface plain(std::move(identity), 1, 1, false);
+    transform3 identity(vector3{0., 0., 0.});
     cylinder3<scalar,false> cylinder = {r, -hz, hz};
     cylinder_intersector ci;
     concentric_cylinder_intersector cci;
@@ -83,8 +75,8 @@ TEST(__plugin, concentric_cylinders)
 
     // The same but bound
     __plugin::cylindrical2 cylindrical2;
-    auto hit_cylinrical = ci.intersect(plain, ori, dir, ctx, cylindrical2, cylinder);
-    auto hit_cocylinrical = cci.intersect(plain, ori, dir, ctx, cylindrical2, cylinder);
+    auto hit_cylinrical = ci.intersect(identity, ori, dir, cylindrical2, cylinder);
+    auto hit_cocylinrical = cci.intersect(identity, ori, dir, cylindrical2, cylinder);
 
     ASSERT_TRUE(hit_cylinrical.status== intersection_status::e_inside);
     ASSERT_TRUE(hit_cocylinrical.status== intersection_status::e_inside);

--- a/tests/common/include/tests/common/test_cylindrical_detector.inl
+++ b/tests/common/include/tests/common/test_cylindrical_detector.inl
@@ -25,14 +25,12 @@ using namespace detray;
 using transform3 = __plugin::transform3;
 using vector3 = __plugin::transform3::vector3;
 using point3 = __plugin::transform3::point3;
-using context = __plugin::transform3::context;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar isclose = 1e-5;
 
 using cdetector = detector<transform3>;
 cdetector d;
-context ctx;
 
 // This test constructs a dimple cylindrical detector
 TEST(__plugin, cylindrical_detector)
@@ -51,8 +49,8 @@ TEST(__plugin, cylindrical_detector)
     cdetector::portal_disc_mask bp_p_disc = {{0., bp_radius}, {0, -1}};
     dvector<cdetector::portal_cylinder_mask> bp_c_portals = {bp_c_ecn, bp_c_b, bp_c_ecp};
     d.add_portal_surface<cdetector::portal_cylinder_mask>(std::move(transform3()), bp_c_portals, bp);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * bp_length), ctx)), {bp_n_disc}, bp);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., 0.5 * bp_length), ctx)), {bp_p_disc}, bp);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * bp_length))), {bp_n_disc}, bp);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., 0.5 * bp_length))), {bp_p_disc}, bp);
     // Insert an actual beam pipe
     darray<scalar, 3> bpm_values = {25., -0.5 * bp_length + 1., 0.5 * bp_length - 1.};
     d.add_surfaces<cdetector::cylinder_mask>({transform3()}, bpm_values, bp);
@@ -67,8 +65,8 @@ TEST(__plugin, cylindrical_detector)
     cdetector::portal_disc_mask px_ecn_ecn = {{px_inner_radius, px_outer_radius}, {-1, 1}};
     cdetector::portal_disc_mask px_ecn_ecp = {{px_inner_radius, px_outer_radius}, {1, 2}};
     d.add_portal_surface<cdetector::portal_cylinder_mask>(std::move(transform3()), {px_ecn_inner, px_ecn_outer}, px_ecn);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * bp_length), ctx)), {px_ecn_ecn}, px_ecn);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * px_barrel), ctx)), {px_ecn_ecp}, px_ecn);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * bp_length))), {px_ecn_ecn}, px_ecn);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * px_barrel))), {px_ecn_ecp}, px_ecn);
     auto endcap_n = endcap_description(29, 50, -px_barrel - 25., 1., 6, 0.2);
     d.add_surfaces<cdetector::trapezoid_mask>(std::get<dvector<transform3>>(endcap_n),
                                              std::get<cdetector::trapezoid_mask::mask_values>(endcap_n),
@@ -80,8 +78,8 @@ TEST(__plugin, cylindrical_detector)
     cdetector::portal_disc_mask px_b_ecn = {{px_inner_radius, px_outer_radius}, {1, 2}};
     cdetector::portal_disc_mask px_b_ecp = {{px_inner_radius, px_outer_radius}, {2, 3}};
     d.add_portal_surface<cdetector::portal_cylinder_mask>(std::move(transform3()), {px_b_inner, px_b_outer}, px_b);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * px_barrel), ctx)), {px_b_ecn}, px_b);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., +0.5 * px_barrel), ctx)), {px_b_ecp}, px_b);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., -0.5 * px_barrel))), {px_b_ecn}, px_b);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., +0.5 * px_barrel))), {px_b_ecp}, px_b);
     auto barrel = barrel_description(33, 0.25, 12, 0.12, 0.25, 600, 2., 7);
     d.add_surfaces<cdetector::rectangle_mask>(std::get<dvector<transform3>>(barrel),
                                              std::get<cdetector::rectangle_mask::mask_values>(barrel),
@@ -93,8 +91,8 @@ TEST(__plugin, cylindrical_detector)
     cdetector::portal_disc_mask px_ecp_ecn = {{px_inner_radius, px_outer_radius}, {2, 3}};
     cdetector::portal_disc_mask px_ecp_ecp = {{px_inner_radius, px_outer_radius}, {3, -1}};
     d.add_portal_surface<cdetector::portal_cylinder_mask>(std::move(transform3()), {px_ecp_inner, px_ecp_outer}, px_ecp);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., 0.5 * px_barrel), ctx)), {px_ecp_ecn}, px_ecp);
-    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., 0.5 * bp_length), ctx)), {px_ecp_ecp}, px_ecp);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., 0.5 * px_barrel))), {px_ecp_ecn}, px_ecp);
+    d.add_portal_surface<cdetector::portal_disc_mask>(std::move(transform3(vector3(0., 0., 0.5 * bp_length))), {px_ecp_ecp}, px_ecp);
     auto endcap_p = endcap_description(29, 50, px_barrel + 25., 1., 6, 0.2);
     d.add_surfaces<cdetector::trapezoid_mask>(std::get<dvector<transform3>>(endcap_p),
                                              std::get<cdetector::trapezoid_mask::mask_values>(endcap_p),

--- a/tests/common/include/tests/common/test_planar_intersection.inl
+++ b/tests/common/include/tests/common/test_planar_intersection.inl
@@ -5,7 +5,6 @@
  * Mozilla Public License Version 2.0
  */
 
-#include "core/surface.hpp"
 #include "core/intersection.hpp"
 #include "masks/rectangle2.hpp"
 #include "tools/planar_intersector.hpp"
@@ -26,7 +25,6 @@ __plugin::cartesian2 cartesian2;
 using transform3 = __plugin::transform3;
 using vector3 = __plugin::transform3::vector3;
 using point3 = __plugin::transform3::point3;
-using context = __plugin::transform3::context;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar isclose = 1e-5;
@@ -34,16 +32,11 @@ constexpr scalar isclose = 1e-5;
 // This defines the local frame test suite
 TEST(__plugin, translated_plane)
 {
-    context ctx;
-    using plane_surface = surface<transform3, int, int>;
-
     // Create a shifted plane
-    transform3 shifted(vector3{3., 2., 10.}, ctx);
-    plane_surface shifted_plane(std::move(shifted), 1, 1, false);
-
+    transform3 shifted(vector3{3., 2., 10.});
     planar_intersector pi;
 
-    auto hit_unbound = pi.intersect(shifted_plane, point3{2., 1., 0.}, vector3{0., 0., 1.}, ctx);
+    auto hit_unbound = pi.intersect(shifted, point3{2., 1., 0.}, vector3{0., 0., 1.});
     ASSERT_TRUE(hit_unbound.status == intersection_status::e_hit);
     ASSERT_TRUE(hit_unbound.direction == intersectiondirection::e_along);
     // Global intersection information
@@ -53,7 +46,7 @@ TEST(__plugin, translated_plane)
     ASSERT_TRUE(hit_unbound.point2 == std::nullopt);
 
     // The same test but bound to local frame
-    auto hit_bound = pi.intersect(shifted_plane, point3{2., 1., 0.}, vector3{0., 0., 1.}, ctx, cartesian2);
+    auto hit_bound = pi.intersect(shifted, point3{2., 1., 0.}, vector3{0., 0., 1.}, cartesian2);
     ASSERT_TRUE(hit_bound.status == intersection_status::e_hit);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound.point3[0], 2., epsilon);
@@ -65,7 +58,7 @@ TEST(__plugin, translated_plane)
 
     // The same test but bound to local frame & masked - inside
     rectangle2<scalar> rect_for_inside = {3., 3.};
-    auto hit_bound_inside = pi.intersect(shifted_plane, point3{2., 1., 0.}, vector3{0., 0., 1.}, ctx, cartesian2, rect_for_inside);
+    auto hit_bound_inside = pi.intersect(shifted, point3{2., 1., 0.}, vector3{0., 0., 1.}, cartesian2, rect_for_inside);
     ASSERT_TRUE(hit_bound_inside.status == intersection_status::e_inside);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound_inside.point3[0], 2., epsilon);
@@ -77,7 +70,7 @@ TEST(__plugin, translated_plane)
 
     // The same test but bound to local frame & masked - outside
     rectangle2<scalar> rect_for_outside = {0.5, 3.5};
-    auto hit_bound_outside = pi.intersect(shifted_plane, point3{2., 1., 0.}, vector3{0., 0., 1.}, ctx, cartesian2, rect_for_outside);
+    auto hit_bound_outside = pi.intersect(shifted, point3{2., 1., 0.}, vector3{0., 0., 1.}, cartesian2, rect_for_outside);
     ASSERT_TRUE(hit_bound_outside.status == intersection_status::e_outside);
     // Global intersection information - unchanged
     ASSERT_NEAR(hit_bound_outside.point3[0], 2., epsilon);

--- a/tests/common/include/tests/common/test_plugin.inl
+++ b/tests/common/include/tests/common/test_plugin.inl
@@ -27,7 +27,6 @@ __plugin::cylindrical2 cylindrical2;
 using transform3 = __plugin::transform3;
 using vector3 = __plugin::transform3::vector3;
 using point3 = __plugin::transform3::point3;
-using context = __plugin::transform3::context;
 
 constexpr scalar epsilon = std::numeric_limits<scalar>::epsilon();
 constexpr scalar isclose = 1e-5;
@@ -141,8 +140,6 @@ TEST(__plugin, getter)
 // This defines the transform3 test suite
 TEST(__plugin, transform3)
 {
-    context ctx;
-
     // Preparatioon work
     vector3 z = vector::normalize(vector3{3., 2., 1.});
     vector3 x = vector::normalize(vector3{2., -3., 0.});
@@ -150,11 +147,11 @@ TEST(__plugin, transform3)
     point3 t = {2., 3., 4.};
 
     // Test constructor from t, z, x
-    transform3 trf(t, z, x, ctx);
+    transform3 trf(t, z, x);
 
     ASSERT_TRUE(trf == trf);
 
-    const auto rot = trf.rotation(ctx);
+    const auto rot = trf.rotation();
     #ifndef __plugin_without_matrix_element_accessor
     ASSERT_NEAR(rot(0, 0), x[0], epsilon);
     ASSERT_NEAR(rot(1, 0), x[1], epsilon);
@@ -167,17 +164,17 @@ TEST(__plugin, transform3)
     ASSERT_NEAR(rot(2, 2), z[2], epsilon);
     #endif
 
-    auto trn = trf.translation(ctx);
+    auto trn = trf.translation();
     ASSERT_NEAR(trn[0], 2., epsilon);
     ASSERT_NEAR(trn[1], 3., epsilon);
     ASSERT_NEAR(trn[2], 4., epsilon);
 
     // Test constructor from matrix
-    auto m44 = trf.matrix(ctx);
-    transform3 trfm(m44, ctx);
+    auto m44 = trf.matrix();
+    transform3 trfm(m44);
 
     // Re-evaluate rot and trn
-    auto rotm = trfm.rotation(ctx);
+    auto rotm = trfm.rotation();
     #ifndef __plugin_without_matrix_element_accessor
     ASSERT_NEAR(rotm(0, 0), x[0], epsilon);
     ASSERT_NEAR(rotm(1, 0), x[1], epsilon);
@@ -190,18 +187,18 @@ TEST(__plugin, transform3)
     ASSERT_NEAR(rotm(2, 2), z[2], epsilon);
     #endif
 
-    auto trnm = trfm.translation(ctx);
+    auto trnm = trfm.translation();
     ASSERT_NEAR(trnm[0], 2., epsilon);
     ASSERT_NEAR(trnm[1], 3., epsilon);
     ASSERT_NEAR(trnm[2], 4., epsilon);
 
     // Check a contruction from an array[16]
     darray<scalar, 16> matray = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0};
-    transform3 trfma(matray, ctx);
+    transform3 trfma(matray);
 
     // Re-evaluate rot and trn
     #ifndef __plugin_without_matrix_element_accessor
-    auto rotma = trfma.rotation(ctx);
+    auto rotma = trfma.rotation();
     ASSERT_NEAR(rotma(0, 0), 1., epsilon);
     ASSERT_NEAR(rotma(1, 0), 0., epsilon);
     ASSERT_NEAR(rotma(2, 0), 0., epsilon);
@@ -213,7 +210,7 @@ TEST(__plugin, transform3)
     ASSERT_NEAR(rotma(2, 2), 1., epsilon);
     #endif
 
-    auto trnma = trfma.translation(ctx);
+    auto trnma = trfma.translation();
     ASSERT_NEAR(trnma[0], 0., epsilon);
     ASSERT_NEAR(trnma[1], 0., epsilon);
     ASSERT_NEAR(trnma[2], 0., epsilon);
@@ -223,26 +220,24 @@ TEST(__plugin, transform3)
 // This test global coordinate transforms
 TEST(__plugin, global_transformations)
 {
-    context ctx;
-
     // Preparatioon work
     vector3 z = vector::normalize(vector3{3., 2., 1.});
     vector3 x = vector::normalize(vector3{2., -3., 0.});
     vector3 y = vector::cross(z, x);
     point3 t = {2., 3., 4.};
-    transform3 trf(t, z, x, ctx);
+    transform3 trf(t, z, x);
 
     // Check that local origin translates into global translation
     point3 lzero = {0., 0., 0.};
-    auto gzero = trf.point_to_global(lzero, ctx);
+    auto gzero = trf.point_to_global(lzero);
     ASSERT_NEAR(gzero[0], t[0], epsilon);
     ASSERT_NEAR(gzero[1], t[1], epsilon);
     ASSERT_NEAR(gzero[2], t[2], epsilon);
 
     // Check a round trip for point
     point3 lpoint = {3., 4., 5.};
-    auto gpoint = trf.point_to_global(lpoint, ctx);
-    auto lpoint_r = trf.point_to_local(gpoint, ctx);
+    auto gpoint = trf.point_to_global(lpoint);
+    auto lpoint_r = trf.point_to_local(gpoint);
     ASSERT_NEAR(lpoint[0], lpoint_r[0], isclose);
     ASSERT_NEAR(lpoint[1], lpoint_r[1], isclose);
     ASSERT_NEAR(lpoint[2], lpoint_r[2], isclose);
@@ -250,18 +245,18 @@ TEST(__plugin, global_transformations)
     // Check a point versus vector transform
     // vector should not change if transformed by a pure translation
     point3 tt = {2., 3., 4.};
-    transform3 ttrf(t, ctx);
+    transform3 ttrf(t);
 
     vector3 gvector = {1., 1., 1};
-    auto lvector = ttrf.vector_to_local(gvector, ctx);
+    auto lvector = ttrf.vector_to_local(gvector);
     ASSERT_NEAR(gvector[0], lvector[0], isclose);
     ASSERT_NEAR(gvector[1], lvector[1], isclose);
     ASSERT_NEAR(gvector[2], lvector[2], isclose);
 
     // Check a round trip for vector
     vector3 lvectorB = {7., 8., 9};
-    vector3 gvectorB = trf.vector_to_local(lvectorB, ctx);
-    vector3 lvectorC = trf.vector_to_global(gvectorB, ctx);
+    vector3 gvectorB = trf.vector_to_local(lvectorB);
+    vector3 lvectorC = trf.vector_to_global(gvectorB);
     ASSERT_NEAR(lvectorB[0], lvectorC[0], isclose);
     ASSERT_NEAR(lvectorB[1], lvectorC[1], isclose);
     ASSERT_NEAR(lvectorB[2], lvectorC[2], isclose);

--- a/tests/common/include/tests/common/test_surfaces.hpp
+++ b/tests/common/include/tests/common/test_surfaces.hpp
@@ -19,14 +19,11 @@ namespace detray
     using transform3 = __plugin::transform3;
     using point3 = transform3::point3;
     using vector3 = transform3::vector3;
-    using context = transform3::context;
 
     /** This method creates a number (distances.size()) planes along a direction 
     */
     dvector<surface<transform3>> planes_along_direction(dvector<scalar> distances, vector3 direction)
     {
-        context ctx;
-
         // Rotation matrix
         vector3 z = direction;
         vector3 x = normalize(vector3{0, -z[2], z[1]});
@@ -36,7 +33,7 @@ namespace detray
         for (auto &d : distances)
         {
             vector3 t = d * direction;
-            transform3 trf(t, z, x, ctx);
+            transform3 trf(t, z, x);
             return_surfaces.push_back(surface<transform3>{std::move(trf), 0, 0, false});
         }
         return return_surfaces;
@@ -61,8 +58,6 @@ namespace detray
                                                                       unsigned int n_phi_half,
                                                                       scalar overlap_phi)
     {
-        context ctx;
-
         scalar module_inner_lx = r_inner*M_PI *(1+overlap_phi)/(n_phi_half);
         scalar module_outer_lx = r_inner*M_PI *(1+overlap_phi)/(n_phi_half);
         scalar module_hy = 0.5*(r_outer - r_inner);
@@ -81,7 +76,7 @@ namespace detray
             point3 p = {r * cos_phi, r * sin_phi, z_pos + z_addon};           
             vector3 z = {0., 0., 1.};
             vector3 x = {-sin_phi, cos_phi, 0.};
-            transforms.push_back(transform3(p, z, x, ctx));
+            transforms.push_back(transform3(p, z, x));
         }
         return { trapezoid_values, transforms };
 
@@ -108,8 +103,6 @@ namespace detray
                                                                       scalar stagger_z,
                                                                       unsigned int n_z)
     {
-        context ctx;
-
         // Estimate module dimensions
         scalar module_lx = 2 * r * M_PI * (1 + overlap_rphi) / n_phi;
         scalar module_ly = (barrel_z + (n_z - 1) * stagger_z) / n_z;
@@ -129,7 +122,7 @@ namespace detray
                 point3 p = {(r+r_addon) * std::cos(phi), (r+r_addon) * std::sin(phi), z_pos};
                 vector3 z = {std::cos(phi + tilt_phi), std::sin(phi + tilt_phi), 0.};
                 vector3 x = {z[1], -z[0], 0.};
-                transforms.push_back(transform3(p, z, x, ctx));
+                transforms.push_back(transform3(p, z, x));
             }
         }
         return {rectangle_bounds, transforms};

--- a/tests/io/include/tests/io/read_csv.hpp
+++ b/tests/io/include/tests/io/read_csv.hpp
@@ -67,7 +67,6 @@ namespace detray
     csv_detector<surface<transform_type, darray<unsigned int, 2>, unsigned int, unsigned int>> read_csv(std::string filename)
     {
 
-        using context = typename transform_type::context;
         using surface = surface<transform_type, darray<unsigned int, 2>, unsigned int, unsigned int>;
 
         struct surface_info
@@ -126,8 +125,7 @@ namespace detray
             float mhy = std::atof(split_strings[19].c_str());
             darray<scalar, 3> mask = {mhx_miny, mhx_maxy, mhy};
 
-            context default_context;
-            read_surface_info[volume_id][layer_id].insert({module_id, {transform_type{matrix_array, default_context}, mask, geo_id}});
+            read_surface_info[volume_id][layer_id].insert({module_id, {transform_type{matrix_array}, mask, geo_id}});
         }
         csv_file.close();
 


### PR DESCRIPTION
This PR decouples the `context` from the `transform` class, it will allow to implement common contextual containers for different plugins.

It also changes the `intersectors` to run on context-resolved transforms rather than surfaces. It prepares for a follow-up PR which will change the  `surface::transform_type` to `surface::transform_link` .

cc @niermann999 - I have already changed the `smatrix` plugin as well.