### PR TITLE
feat: introduce axis

### DIFF
--- a/core/include/geometry/detector.hpp
+++ b/core/include/geometry/detector.hpp
@@ -12,6 +12,7 @@
 #include "masks/trapezoid2.hpp"
 #include "masks/cylinder3.hpp"
 #include "masks/ring2.hpp"
+#include "utils/indexing.hpp"
 #include "utils/containers.hpp"
 #include "tools/concentric_cylinder_intersector.hpp"
 
@@ -35,10 +36,8 @@ namespace detray
         using surface_intersection = intersection<scalar, point3, point2>;
 
         // Indexing
-        using optional_index = int;
-        using guaranteed_index = unsigned long;
+
         using typed_guaranteed_index = darray<guaranteed_index, 2>;
-        using guaranteed_range = darray<guaranteed_index, 2>;
         using typed_guaranteed_range = dtuple<guaranteed_index, guaranteed_range>;
 
         // Surface finding function

--- a/core/include/grids/axis.hpp
+++ b/core/include/grids/axis.hpp
@@ -1,0 +1,143 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "utils/indexing.hpp"
+
+#include <iostream>
+
+namespace detray
+{
+
+    namespace axis
+    {
+        /** A regular closed axis.
+         * 
+         * @tparam kDIM the number of bins
+         * @tparam value_type the scalar value which is used
+         * 
+         * The axis is closed, i.e. each underflow bin is mapped to 0
+         * and henceforth each overflow bin is mapped to kDIM-1
+         */
+        template <unsigned int kDIM, typename value_type = scalar>
+        struct closed
+        {
+
+            value_type _min;
+            value_type _max;
+
+            static constexpr unsigned int bins = kDIM;
+
+            /** Access function to a single bin from a value v
+             * 
+             * @param v is the value for the bin search
+             * 
+             * As the axis is closed it @returns a guaranteed_index type
+             **/
+            guaranteed_index bin(value_type v) const
+            {
+                optional_index ibin = static_cast<optional_index>((v - _min) / (_max - _min) * kDIM);
+                return (ibin >= 0 and ibin < kDIM) ? static_cast<guaranteed_index>(ibin)
+                       : ibin < 0                  ? 0
+                                                   : static_cast<guaranteed_index>(kDIM - 1);
+            }
+
+            /** Access function to a range with binned neighbourhood
+             * 
+             * @param v is the value for the bin search
+             * @param nhood is the neighbourhood size (+/-) 
+             * 
+             * As the axis is closed it @returns a guaranteed_range
+             **/
+            guaranteed_range range(value_type v, unsigned int nhood) const
+            {
+                optional_index ibin = static_cast<optional_index>((v - _min) / (_max - _min) * kDIM);
+                guaranteed_index min_bin = (ibin - nhood) >= 0 ? static_cast<guaranteed_index>(ibin - nhood) : 0;
+                guaranteed_index max_bin = (ibin + nhood) < kDIM ? static_cast<guaranteed_index>(ibin + nhood) : static_cast<guaranteed_index>(kDIM - 1);
+                return {min_bin, max_bin};
+            }
+
+            /** Access function to a zone with binned neighbourhood
+             * 
+             * @param v is the value for the bin search
+             * @param nhood is the neighbourhood size (+/-) 
+             * 
+             * As the axis is closed it @returns a guaranteed_sequence
+             **/
+            guaranteed_sequence zone(value_type v, unsigned int nhood) const
+            {
+                guaranteed_range nh_range = range(v, nhood);
+                guaranteed_sequence sequence(static_cast<guaranteed_sequence::size_type>(nh_range[1] - nh_range[0] + 1), nh_range[0]);
+                guaranteed_index m = 0;
+                std::for_each(sequence.begin(), sequence.end(), [&](auto &n) { n += m++; });
+                return sequence;
+            }
+        };
+
+        /** A regular circular axis.
+         * 
+         * @tparam kDIM the number of bins
+         * @tparam value_type the scalar value which is used
+         * 
+         * The axis is circular, i.e. the underflow bins map into the circular sequence
+         * 
+         */
+        template <unsigned int kDIM, typename value_type = scalar>
+        struct circular
+        {
+
+            value_type _min;
+            value_type _max;
+
+            static constexpr unsigned int bins = kDIM;
+
+            /** Access function to a single bin from a value v
+             * 
+             * @param v is the value for the bin search
+             * 
+             * As the axis is closed it @returns a guaranteed_index type
+             **/
+            guaranteed_index bin(value_type v) const
+            {
+                optional_index ibin = static_cast<optional_index>((v - _min) / (_max - _min) * kDIM);
+                return (ibin >= 0 and ibin < kDIM) ? static_cast<guaranteed_index>(ibin)
+                       : ibin < 0                  ? static_cast<guaranteed_index>(kDIM + ibin)
+                                                   : static_cast<guaranteed_index>(kDIM - ibin);
+            }
+
+            /** Access function to a range with binned neighbourhood
+             * 
+             * @param v is the value for the bin search
+             * @param nhood is the neighbourhood size (+/-) 
+             * 
+             * As the axis is circular it @returns a guaranteed_range
+             **/
+            guaranteed_range range(value_type v, unsigned int nhood) const
+            {
+                return {0u, 0u};
+            }
+
+            /** Access function to a zone with binned neighbourhood
+             * 
+             * @param v is the value for the bin search
+             * @param nhood is the neighbourhood size (+/-) 
+             * 
+             * As the axis is closed it @returns a guaranteed_sequence
+             **/
+            guaranteed_sequence zone(value_type v, unsigned int nhood) const
+            {
+                // guaranteed_range nh_range = range(v, nhood);
+                // guaranteed_sequence sequence(static_cast<guaranteed_sequence::size_type>(nh_range[1] - nh_range[0] + 1), nh_range[0]);
+                return {};
+            }
+
+        };
+
+    } // namespace axis
+
+} // namespace detray

--- a/core/include/grids/axis.hpp
+++ b/core/include/grids/axis.hpp
@@ -10,6 +10,7 @@
 #include "utils/indexing.hpp"
 
 #include <iostream>
+#include <algorithm>
 
 namespace detray
 {

--- a/core/include/grids/grid2.hpp
+++ b/core/include/grids/grid2.hpp
@@ -1,0 +1,35 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "utils/containers.hpp"
+
+namespace detray
+{
+
+    template <typename value_type, 
+              typename axis_p0_type, 
+              typename axis_p1_type, 
+              typename serializer_type>
+    struct grid2
+    {
+        darray<value_type, typename axis_p0_type::kBins, * typename axis_p1_type::kBins> _data_serialized;
+
+
+        value_type bin() const {
+
+        }
+
+        dvector<value_type> zone() const {
+
+
+        }
+
+    };
+
+} // namespace detray

--- a/core/include/tools/navigator.hpp
+++ b/core/include/tools/navigator.hpp
@@ -5,6 +5,11 @@
  * 
  * Mozilla Public License Version 2.0
  */
+
+#pragma once
+
+#include "utils/indexing.hpp"
+
 namespace detray
 {
     template <typename detector_type>
@@ -16,9 +21,6 @@ namespace detray
         using portal_surface = typename detector_type::portal_surface;
         using portal_links = typename detector_type::portal_links;
         using transform_type = typename detector_type::transform3;
-
-        // Indexing
-        using guaranteed_index = typename detector_type::guaranteed_index;
 
         /** Simple navigation status struct */
         enum navigation_status : int
@@ -143,7 +145,6 @@ namespace detray
                                  const mask_container &masks,
                                  bool trust = false)
         {
-            // That the guaranteed index in the container
             const auto &typed_mask_range = surface.mask();
             if (std::get<0>(typed_mask_range) == 0)
             {

--- a/core/include/utils/indexing.hpp
+++ b/core/include/utils/indexing.hpp
@@ -1,0 +1,20 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "utils/containers.hpp"
+
+namespace detray
+{
+
+    using optional_index = int;
+    using guaranteed_index = unsigned long;
+    using guaranteed_range = darray<guaranteed_index, 2>;
+    using guaranteed_sequence = dvector<guaranteed_index>;
+
+} // namespace detray

--- a/tests/unit_tests/core/CMakeLists.txt
+++ b/tests/unit_tests/core/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_detray_test(grids_axis
+                grids_axis.cpp detray::core)
+
 add_detray_test(utils_enumerate
                 utils_enumerate.cpp detray::core)
 

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -37,7 +37,6 @@ TEST(grids, regular_closed_axis)
     EXPECT_EQ(ten_bins.zone(2., 1), expected_zone);
     expected_zone = {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u};
     EXPECT_EQ(ten_bins.zone(1., 4), expected_zone);
-
 }
 
 TEST(grids, regular_circular_axis)
@@ -46,7 +45,9 @@ TEST(grids, regular_circular_axis)
 
     // Let's say 36 modules, but with 4 directly at 0, pi/2, pi, -pi2
     scalar half_module = 2 * M_PI_2 / 72;
-    axis::circular<36> full_pi = {-M_PI + half_module, M_PI - half_module};
+    scalar phi_min = -M_PI + half_module;
+    scalar phi_max = M_PI - half_module;
+    axis::circular<36> full_pi = {phi_min, phi_max};
     // N bins
     EXPECT_EQ(full_pi.bins, 36u);
     // Axis bin access

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -1,0 +1,73 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "tests/common/test_defs.hpp"
+#include "grids/axis.hpp"
+#include "utils/indexing.hpp"
+
+#include <gtest/gtest.h>
+
+#include <climits>
+
+using namespace detray;
+
+TEST(grids, regular_closed_axis)
+{
+
+    axis::closed<10> ten_bins{-3., 7.};
+    // N bins
+    EXPECT_EQ(ten_bins.bins, 10u);
+    // Axis bin access
+    EXPECT_EQ(ten_bins.bin(-4.), 0u);
+    EXPECT_EQ(ten_bins.bin(2.), 5u);
+    EXPECT_EQ(ten_bins.bin(8.), 9u);
+    // Axis range access
+    guaranteed_range expected_range = {4u, 6u};
+    EXPECT_EQ(ten_bins.range(2., 1), expected_range);
+    expected_range = {0u, 8u};
+    EXPECT_EQ(ten_bins.range(1., 4), expected_range);
+    expected_range = {3u, 9u};
+    EXPECT_EQ(ten_bins.range(5., 5), expected_range);
+    // Axis sequence access
+    guaranteed_sequence expected_zone = {4u, 5u, 6u};
+    EXPECT_EQ(ten_bins.zone(2., 1), expected_zone);
+    expected_zone = {0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u};
+    EXPECT_EQ(ten_bins.zone(1., 4), expected_zone);
+
+}
+
+TEST(grids, regular_circular_axis)
+{
+    scalar epsilon = 10 * std::numeric_limits<scalar>::epsilon();
+
+    // Let's say 36 modules, but with 4 directly at 0, pi/2, pi, -pi2
+    scalar half_module = 2 * M_PI_2 / 72;
+    axis::circular<36> full_pi = {-M_PI + half_module, M_PI - half_module};
+    // N bins
+    EXPECT_EQ(full_pi.bins, 36u);
+    // Axis bin access
+    EXPECT_EQ(full_pi.bin(M_PI - epsilon), 0u);
+    EXPECT_EQ(full_pi.bin(M_PI + epsilon), 0u);
+    EXPECT_EQ(full_pi.bin(0), 18u);
+    // Axis range access
+    guaranteed_range expected = {4u, 6u};
+    //EXPECT_EQ(ten_bins.zone(2., 1), expected);
+    //expected = {0u, 8u};
+    //EXPECT_EQ(ten_bins.zone(1., 4), expected);
+    //expected = { 3u, 9u};
+    //EXPECT_EQ(ten_bins.zone(5., 5), expected);
+}
+
+// Google Test can be run manually from the main() function
+// or, it can be linked to the gtest_main library for an already
+// set-up main() function primed to accept Google Test test cases.
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/unit_tests/core/grids_axis.cpp
+++ b/tests/unit_tests/core/grids_axis.cpp
@@ -54,13 +54,22 @@ TEST(grids, regular_circular_axis)
     EXPECT_EQ(full_pi.bin(M_PI - epsilon), 0u);
     EXPECT_EQ(full_pi.bin(M_PI + epsilon), 0u);
     EXPECT_EQ(full_pi.bin(0), 18u);
+    // Remap test
+    EXPECT_EQ(full_pi.remap(4, -1), 3u);
+    EXPECT_EQ(full_pi.remap(4, 1), 5u);
+    EXPECT_EQ(full_pi.remap(0, -1), 35);
+    EXPECT_EQ(full_pi.remap(0, -2), 34);
+    EXPECT_EQ(full_pi.remap(-1, -1), 34);
+    EXPECT_EQ(full_pi.remap(35, 1), 0);
     // Axis range access
-    guaranteed_range expected = {4u, 6u};
-    //EXPECT_EQ(ten_bins.zone(2., 1), expected);
-    //expected = {0u, 8u};
-    //EXPECT_EQ(ten_bins.zone(1., 4), expected);
-    //expected = { 3u, 9u};
-    //EXPECT_EQ(ten_bins.zone(5., 5), expected);
+
+    guaranteed_range expected_range = {35u, 1u};
+    EXPECT_EQ(full_pi.range(M_PI + epsilon, 1), expected_range);
+    expected_range = {34u, 2u};
+    EXPECT_EQ(full_pi.range(M_PI + epsilon, 2), expected_range);
+    // Zone test
+    guaranteed_sequence expected_zone = {34u, 35u, 0u, 1u, 2u};
+    EXPECT_EQ(full_pi.zone(M_PI + epsilon, 2), expected_zone);
 }
 
 // Google Test can be run manually from the main() function


### PR DESCRIPTION
This PR introduces basic `axis` types and adds a unit test.

For the moment, a regular closed axis and a circular axis are available, which is sufficient for the TrackML detector.
