### PR TITLE
feat: introduce serializer

### DIFF
--- a/core/include/grids/serializer2.hpp
+++ b/core/include/grids/serializer2.hpp
@@ -1,0 +1,56 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "utils/indexing.hpp"
+#include "utils/containers.hpp"
+
+#include <algorithm>
+
+namespace detray
+{
+    /** Struct that helps taking a two-dimensional binning into
+     * a serial binning for data storage.
+     * 
+     * Serializers allow to create a memory local environment if
+     * advantegeous. 
+     * 
+     **/
+    struct serializer2
+    {
+        /** Create a serial bin from two individual bins 
+         * 
+         * @tparam faxis_type is the type of the first axis
+         * @tparam saxis_type is the type of the second axis
+         * 
+         * @return a guaranteed_index for the memory storage
+         */
+        template <typename faxis_type, typename saxis_type>
+        guaranteed_index serialize(guaranteed_index fbin, guaranteed_index sbin) const
+        {
+            guaranteed_index offset = sbin * faxis_type::bins;
+            return offset + fbin;
+        }
+
+        /** Create a bin tuple from a serialized bin
+         * 
+         * @tparam faxis_type is the type of the first axis
+         * @tparam saxis_type is the type of the second axis
+         * 
+         * @return a 2-dim array of guaranteed_index 
+         */
+        template <typename faxis_type, typename saxis_type>
+        darray<guaranteed_index, 2> deserialize(guaranteed_index serialbin) const
+        {
+            guaranteed_index sbin = static_cast<guaranteed_index>(serialbin/faxis_type::bins);
+            guaranteed_index fbin = serialbin - sbin * faxis_type::bins;
+            return { fbin, sbin };
+        }
+    };
+
+} // namespace detray

--- a/tests/unit_tests/core/grids_serializer.cpp
+++ b/tests/unit_tests/core/grids_serializer.cpp
@@ -1,0 +1,60 @@
+/** Detray library, part of the ACTS project (R&D line)
+ * 
+ * (c) 2020 CERN for the benefit of the ACTS project
+ * 
+ * Mozilla Public License Version 2.0
+ */
+
+#include "tests/common/test_defs.hpp"
+#include "grids/axis.hpp"
+#include "grids/serializer2.hpp"
+#include "utils/indexing.hpp"
+
+#include <gtest/gtest.h>
+
+#include <climits>
+
+using namespace detray;
+
+TEST(grids, serialize_deserialize)
+{
+
+    axis::closed<6> r6{-3., 7.};
+    axis::circular<12> c12{-3., 3.};
+
+    serializer2 ser2;
+
+    // Serializing
+    guaranteed_index test = ser2.serialize<decltype(r6), decltype(c12)>(0u, 0u);
+    EXPECT_EQ(test, 0u);
+    test = ser2.serialize<decltype(r6), decltype(c12)>(5u, 0u);
+    EXPECT_EQ(test, 5u);
+    test = ser2.serialize<decltype(r6), decltype(c12)>(0u, 1u);
+    EXPECT_EQ(test, 6u);
+    test = ser2.serialize<decltype(r6), decltype(c12)>(5u, 2u);
+    EXPECT_EQ(test, 17u);
+
+    // Deserialize
+    darray<guaranteed_index, 2> expected_array = {0u, 0u};
+    darray<guaranteed_index, 2> test_array = ser2.deserialize<decltype(r6), decltype(c12)>(0u);
+    EXPECT_EQ(test_array, expected_array);
+    expected_array = {5u, 0u};
+    test_array = ser2.deserialize<decltype(r6), decltype(c12)>(5u);
+    EXPECT_EQ(test_array, expected_array);
+    expected_array = {0u, 1u};
+    test_array = ser2.deserialize<decltype(r6), decltype(c12)>(6u);
+    EXPECT_EQ(test_array, expected_array);
+    expected_array = {5u, 2u};
+    test_array = ser2.deserialize<decltype(r6), decltype(c12)>(17u);
+    EXPECT_EQ(test_array, expected_array);
+}
+
+// Google Test can be run manually from the main() function
+// or, it can be linked to the gtest_main library for an already
+// set-up main() function primed to accept Google Test test cases.
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR introduces a small struct that adds a `serializer` for grids. For the moment, only a jump-serialiser is available.