### PR TITLE
feat: adding grid shift

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "extern/benchmark"]
 	path = extern/benchmark
 	url = https://github.com/google/benchmark.git
+[submodule "extern/json"]
+	path = extern/json
+	url = https://github.com/nlohmann/json.git

--- a/core/include/grids/grid2.hpp
+++ b/core/include/grids/grid2.hpp
@@ -43,10 +43,20 @@ namespace detray
          **/
         grid2(axis_p0_type &&axis_p0, axis_p1_type &&axis_p1) : _axis_p0(std::move(axis_p0)), _axis_p1(std::move(axis_p1))
         {
-            for (auto &d : _data_serialized)
+            for (auto &ds : _data_serialized)
             {
-                d = _populator.init();
+                ds = _populator.init();
             }
+        }
+
+        /** Allow for grid shift, when using a centralized store and indices
+        * 
+        * @param offset is the applied offset shift
+        * 
+        **/
+        void shift(const typename populator_type::bare_value &offset)
+        {
+            std::for_each(_data_serialized.begin(), _data_serialized.end(), [&](auto &ds) { _populator.shift(ds, offset); });
         }
 
         /** Fill/populate operation

--- a/core/include/grids/populator.hpp
+++ b/core/include/grids/populator.hpp
@@ -54,6 +54,17 @@ namespace detray
             return {};
         }
 
+        /** Shift operation for unified memory block
+         * 
+         * @param stored the stored value
+         * @param offset is the shift offset
+         * 
+         **/
+        void shift(store_value &stored, const bare_value &offset) const
+        {
+            stored += offset;
+        }
+
         /** Return an initialized bin value
          */
         store_value init() const
@@ -120,6 +131,17 @@ namespace detray
             return s;
         }
 
+        /** Shift operation for unified memory block
+         * 
+         * @param stored the stored value
+         * @param offset is the shift offset
+         * 
+         **/
+        void shift(store_value &stored, const bare_value &offset) const
+        {
+            std::for_each(stored.begin(), stored.end(), [&](auto &d) { d += offset; });
+        }
+
         /** Return an initialized bin value
          **/
         store_value init() const
@@ -170,6 +192,17 @@ namespace detray
         dvector<bare_value> sequence(store_value &stored) const
         {
             return stored;
+        }
+
+        /** Shift operation for unified memory block
+         * 
+         * @param stored the stored value
+         * @param offset is the shift offset
+         * 
+         **/
+        void shift(store_value &stored, const bare_value &offset) const
+        {
+            std::for_each(stored.begin(), stored.end(), [&](auto &d) { d += offset; });
         }
 
         /** Return an initialized bin value

--- a/tests/unit_tests/core/grids_grid2.cpp
+++ b/tests/unit_tests/core/grids_grid2.cpp
@@ -210,6 +210,28 @@ TEST(grids, grid2_attach_populator)
     EXPECT_EQ(zone_test, zone_expected);
 }
 
+
+TEST(grids, grid2_shift)
+{
+    replace_populator<guaranteed_index, 0> replacer;
+    serializer2 serializer;
+
+    axis::closed<10> xaxis{-5., 5.};
+    axis::closed<10> yaxis{-5., 5.};
+
+    using grid2r = grid2<decltype(replacer), decltype(xaxis), decltype(yaxis), decltype(serializer)>;
+
+    grid2r g2(std::move(xaxis), std::move(yaxis));
+
+    // Test the initialization
+    test::point2 p = {-4.5, -4.5};
+    EXPECT_EQ(g2.bin(p), 0u);
+
+    g2.shift(8u);
+    EXPECT_EQ(g2.bin(p), 8u);
+
+}
+
 // Google Test can be run manually from the main() function
 // or, it can be linked to the gtest_main library for an already
 // set-up main() function primed to accept Google Test test cases.


### PR DESCRIPTION
This PR adds the possibility to shift a grid by a constant `bare_value`. This feature is needed when creating one memory block of e.g. surfaces, transforms, and then stitch them together.

