### PR TITLE
Enforce compile time type condition resolution for masks

### DIFF
--- a/core/include/masks/annulus2.hpp
+++ b/core/include/masks/annulus2.hpp
@@ -79,7 +79,7 @@ namespace detray
            // The two quantities to check: r^2 in module system, phi in strips system
 
            // In cartesian coordinates go to modules system by shifting origin
-           if (typeid(local_type) == typeid(__plugin::cartesian2)) {
+           if constexpr(std::is_same_v<local_type, __plugin::cartesian2>) {
               // Calculate radial coordinate in module system:
               scalar_type x_mod = p[0] - _values[4];
               scalar_type y_mod = p[1] - _values[5];

--- a/core/include/masks/ring2.hpp
+++ b/core/include/masks/ring2.hpp
@@ -61,7 +61,7 @@ namespace detray
                                        scalar_type t0 = std::numeric_limits<scalar_type>::epsilon(),
                                        scalar_type t1 = std::numeric_limits<scalar_type>::epsilon()) const
         {
-            if (typeid(local_type) == typeid(__plugin::cartesian2)) {
+            if constexpr(std::is_same_v<local_type, __plugin::cartesian2>) {
                scalar_type r = getter::perp(p);
                return (r + t0 >= _values[0] and r <= _values[1] + t0) ? e_inside : e_outside;
             }


### PR DESCRIPTION
To make sure everything is dealt with at compile time in the type based branching that is done for masks that differentiate between cartesian and polar coordinates.